### PR TITLE
Reduce periphery image size

### DIFF
--- a/bin/periphery/Dockerfile
+++ b/bin/periphery/Dockerfile
@@ -1,21 +1,24 @@
 # Build Periphery
-FROM rust:1.80.1-bookworm AS builder
+FROM rust:1.80.1-alpine AS builder
 WORKDIR /builder
 COPY . .
+RUN apk update && apk --no-cache add musl-dev openssl-dev openssl-libs-static
 RUN cargo build -p komodo_periphery --release
 
 # Final Image
-FROM debian:bookworm-slim
+FROM alpine:3.20
 
 # Install Deps
-RUN apt update && apt install -y git curl ca-certificates && \
-	curl -fsSL https://get.docker.com | sh
+RUN apk update && apk add docker-cli docker-cli-compose openssl git git-lfs bash
+
+# Setup an application directory
+WORKDIR /app
 
 # Copy
-COPY --from=builder /builder/target/release/periphery /
+COPY --from=builder /builder/target/release/periphery /app
 
 # Hint at the port
-EXPOSE 8120
+EXPOSE 8120 
 
 # Label for Ghcr
 LABEL org.opencontainers.image.source=https://github.com/mbecker20/komodo
@@ -23,4 +26,4 @@ LABEL org.opencontainers.image.description="Komodo Periphery"
 LABEL org.opencontainers.image.licenses=GPL-3.0
 
 # Using ENTRYPOINT allows cli args to be passed, eg using "command" in docker compose.
-ENTRYPOINT [ "./periphery" ]
+ENTRYPOINT [ "/app/periphery" ]

--- a/bin/periphery/slim.Dockerfile
+++ b/bin/periphery/slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build Periphery
-FROM rust:1.80.1-alpine AS builder
+FROM rust:1.81.0-alpine AS builder
 WORKDIR /builder
 COPY . .
 RUN apk update && apk --no-cache add musl-dev openssl-dev openssl-libs-static

--- a/bin/periphery/slim.Dockerfile
+++ b/bin/periphery/slim.Dockerfile
@@ -1,21 +1,24 @@
 # Build Periphery
-FROM rust:1.81.0-bookworm AS builder
+FROM rust:1.80.1-alpine AS builder
 WORKDIR /builder
 COPY . .
+RUN apk update && apk --no-cache add musl-dev openssl-dev openssl-libs-static
 RUN cargo build -p komodo_periphery --release
 
 # Final Image
-FROM debian:bookworm-slim
+FROM alpine:3.20
 
 # Install Deps
-RUN apt update && apt install -y git curl ca-certificates && \
-	curl -fsSL https://get.docker.com | sh
+RUN apk update && apk add docker-cli docker-cli-compose openssl git git-lfs bash
+
+# Setup an application directory
+WORKDIR /app
 
 # Copy
-COPY --from=builder /builder/target/release/periphery /
+COPY --from=builder /builder/target/release/periphery /app
 
 # Hint at the port
-EXPOSE 8120
+EXPOSE 8120 
 
 # Label for Ghcr
 LABEL org.opencontainers.image.source=https://github.com/mbecker20/komodo
@@ -23,4 +26,4 @@ LABEL org.opencontainers.image.description="Komodo Periphery"
 LABEL org.opencontainers.image.licenses=GPL-3.0
 
 # Using ENTRYPOINT allows cli args to be passed, eg using "command" in docker compose.
-ENTRYPOINT [ "./periphery" ]
+ENTRYPOINT [ "/app/periphery" ]


### PR DESCRIPTION
## Periphery Image Size Optimization
The original image was approximately 700 MB, which I believe can be significantly reduced. For comparison, the Portainer agent image is around 200 MB.

To achieve this reduction, I refactored the base image to use Alpine instead of Debian-slim, including only the necessary dependencies.

After that I got an image around 150 MB.

All functionality appears to remain consistent with the previous image.

I have do some tests : 
- Deploy and Remove a stack
- Build an image from a repository
- Prune system images
- Read some containers logs
- Prune volumes


![image](https://github.com/user-attachments/assets/8eb75919-50c6-42a3-b297-aedff6595028)
