### PR TITLE
fix: change edit url for docsite

### DIFF
--- a/docsite/docusaurus.config.ts
+++ b/docsite/docusaurus.config.ts
@@ -41,17 +41,13 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./sidebars.ts",
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/mbecker20/komodo/tree/main/docsite",
         },
         blog: {
           showReadingTime: true,
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/mbecker20/komodo/tree/main/docsite",
         },
         theme: {
           customCss: "./src/css/custom.css",
@@ -61,7 +57,6 @@ const config: Config = {
   ],
 
   themeConfig: {
-    // Replace with your project's social card
     image: "img/monitor-lizard.png",
     docs: {
       sidebar: {


### PR DESCRIPTION
Changes the default edit url provided by the docusaurus template to the correct komodo url.