### PR TITLE
1.15.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "alerter"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -201,9 +201,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "1.5.7"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
+checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.75.0"
+version = "1.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6787d920877cca6a4ee3953093f6a47cefe26de95a4f7b3681c5850bfe657b4"
+checksum = "4bb6f841697b994ec3a020c560b52693bc9fcb7b9c69210088ab56e03df23b5e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.44.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
+checksum = "e33ae899566f3d395cbf42858e433930682cc9c1889fa89318896082fef45efb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.45.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
+checksum = "f39c09e199ebd96b9f860b0fce4b6625f211e064ad7c8693b72ecf7ef03881e0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.44.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
+checksum = "3d95f93a98130389eb6233b9d615249e543f6c24a68ca1f109af9ca5164a8765"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "command"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "komodo_client",
  "run_command",
@@ -1149,18 +1149,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.77",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "environment_file"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "thiserror",
 ]
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "formatting"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "serror",
 ]
@@ -1452,9 +1452,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1467,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1477,15 +1477,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1494,15 +1494,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1511,21 +1511,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1571,7 +1571,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "command",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_cli"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_client"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_core"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_periphery"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "migrator"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -3102,7 +3102,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "periphery_client"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -4250,9 +4250,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.31.4"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+checksum = "e3b5ae3f4f7d64646c46c4cae4e3f01d1c5d255c7406fdd7c7f999a94e488791"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4880,7 +4880,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update_logger"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "komodo_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["bin/*", "lib/*", "client/core/rs", "client/periphery/rs"]
 
 [workspace.package]
-version = "1.15.3"
+version = "1.15.4"
 edition = "2021"
 authors = ["mbecker20 <becker.maxh@gmail.com>"]
 license = "GPL-3.0-or-later"
@@ -44,8 +44,8 @@ svi = "1.0.1"
 reqwest = { version = "0.12.8", features = ["json"] }
 tokio = { version = "1.38.1", features = ["full"] }
 tokio-util = "0.7.12"
-futures = "0.3.30"
-futures-util = "0.3.30"
+futures = "0.3.31"
+futures-util = "0.3.31"
 
 # SERVER
 axum-extra = { version = "0.9.4", features = ["typed-header"] }
@@ -76,7 +76,7 @@ opentelemetry = "0.25.0"
 tracing = "0.1.40"
 
 # CONFIG
-clap = { version = "4.5.19", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive"] }
 dotenvy = "0.15.7"
 envy = "0.4.2"
 
@@ -95,14 +95,14 @@ hex = "0.4.3"
 
 # SYSTEM
 bollard = "0.17.1"
-sysinfo = "0.31.4"
+sysinfo = "0.32.0"
 
 # CLOUD
-aws-config = "1.5.7"
-aws-sdk-ec2 = "1.75.0"
+aws-config = "1.5.8"
+aws-sdk-ec2 = "1.77.0"
 
 # MISC
-derive_builder = "0.20.1"
+derive_builder = "0.20.2"
 typeshare = "1.0.3"
 octorust = "0.7.0"
 dashmap = "6.1.0"

--- a/bin/core/src/api/read/deployment.rs
+++ b/bin/core/src/api/read/deployment.rs
@@ -88,7 +88,11 @@ const MAX_LOG_LENGTH: u64 = 5000;
 impl Resolve<GetDeploymentLog, User> for State {
   async fn resolve(
     &self,
-    GetDeploymentLog { deployment, tail }: GetDeploymentLog,
+    GetDeploymentLog {
+      deployment,
+      tail,
+      timestamps,
+    }: GetDeploymentLog,
     user: User,
   ) -> anyhow::Result<Log> {
     let Deployment {
@@ -109,6 +113,7 @@ impl Resolve<GetDeploymentLog, User> for State {
       .request(api::container::GetContainerLog {
         name,
         tail: cmp::min(tail, MAX_LOG_LENGTH),
+        timestamps,
       })
       .await
       .context("failed at call to periphery")
@@ -123,6 +128,7 @@ impl Resolve<SearchDeploymentLog, User> for State {
       terms,
       combinator,
       invert,
+      timestamps,
     }: SearchDeploymentLog,
     user: User,
   ) -> anyhow::Result<Log> {
@@ -146,6 +152,7 @@ impl Resolve<SearchDeploymentLog, User> for State {
         terms,
         combinator,
         invert,
+        timestamps,
       })
       .await
       .context("failed at call to periphery")

--- a/bin/core/src/api/read/server.rs
+++ b/bin/core/src/api/read/server.rs
@@ -404,6 +404,7 @@ impl Resolve<GetContainerLog, User> for State {
       server,
       container,
       tail,
+      timestamps,
     }: GetContainerLog,
     user: User,
   ) -> anyhow::Result<Log> {
@@ -417,6 +418,7 @@ impl Resolve<GetContainerLog, User> for State {
       .request(periphery::container::GetContainerLog {
         name: container,
         tail: cmp::min(tail, MAX_LOG_LENGTH),
+        timestamps,
       })
       .await
       .context("failed at call to periphery")
@@ -432,6 +434,7 @@ impl Resolve<SearchContainerLog, User> for State {
       terms,
       combinator,
       invert,
+      timestamps,
     }: SearchContainerLog,
     user: User,
   ) -> anyhow::Result<Log> {
@@ -447,6 +450,7 @@ impl Resolve<SearchContainerLog, User> for State {
         terms,
         combinator,
         invert,
+        timestamps,
       })
       .await
       .context("failed at call to periphery")

--- a/bin/core/src/api/read/stack.rs
+++ b/bin/core/src/api/read/stack.rs
@@ -70,6 +70,7 @@ impl Resolve<GetStackServiceLog, User> for State {
       stack,
       service,
       tail,
+      timestamps,
     }: GetStackServiceLog,
     user: User,
   ) -> anyhow::Result<GetStackServiceLogResponse> {
@@ -85,6 +86,7 @@ impl Resolve<GetStackServiceLog, User> for State {
         project: stack.project_name(false),
         service,
         tail,
+        timestamps,
       })
       .await
       .context("failed to get stack service log from periphery")
@@ -100,6 +102,7 @@ impl Resolve<SearchStackServiceLog, User> for State {
       terms,
       combinator,
       invert,
+      timestamps,
     }: SearchStackServiceLog,
     user: User,
   ) -> anyhow::Result<SearchStackServiceLogResponse> {
@@ -117,6 +120,7 @@ impl Resolve<SearchStackServiceLog, User> for State {
         terms,
         combinator,
         invert,
+        timestamps,
       })
       .await
       .context("failed to get stack service log from periphery")

--- a/bin/core/src/main.rs
+++ b/bin/core/src/main.rs
@@ -44,7 +44,7 @@ async fn app() -> anyhow::Result<()> {
   );
   tokio::join!(
     // Maybe initialize first server
-    helpers::ensure_first_server(),
+    helpers::ensure_first_server_and_builder(),
     // Cleanup open updates / invalid alerts
     helpers::startup_cleanup(),
   );

--- a/bin/core/src/resource/mod.rs
+++ b/bin/core/src/resource/mod.rs
@@ -514,8 +514,7 @@ pub async fn create<T: KomodoResource>(
     .await
     .context("Failed to list all resources for duplicate name check")?
     .into_iter()
-    .find(|r| r.name == name)
-    .is_some()
+    .any(|r| r.name == name)
   {
     return Err(anyhow!("Must provide unique name for resource."));
   }

--- a/bin/core/src/sync/toml.rs
+++ b/bin/core/src/sync/toml.rs
@@ -274,7 +274,7 @@ impl ToToml for Build {
     config
       .into_iter()
       .map(|(key, value)| match key.as_str() {
-        "builder_id" => return Ok((String::from("builder"), value)),
+        "builder_id" => Ok((String::from("builder"), value)),
         "version" => {
           match (
             &resource.config.version,

--- a/bin/periphery/src/api/build.rs
+++ b/bin/periphery/src/api/build.rs
@@ -87,10 +87,22 @@ impl Resolve<build::Build> for State {
     // Get command parts
     let image_name =
       get_image_name(&build).context("failed to make image name")?;
-    let build_args = parse_build_args(
-      &environment_vars_from_str(build_args)
-        .context("Invalid build_args")?,
-    );
+
+    // Add VERSION to build args (if not already there)
+    let mut build_args = environment_vars_from_str(build_args)
+      .context("Invalid build_args")?;
+    if build_args
+      .iter()
+      .find(|a| a.variable == "VERSION")
+      .is_none()
+    {
+      build_args.push(EnvironmentVar {
+        variable: String::from("VERSION"),
+        value: build.config.version.to_string(),
+      });
+    }
+    let build_args = parse_build_args(&build_args);
+
     let secret_args = environment_vars_from_str(secret_args)
       .context("Invalid secret_args")?;
     let _secret_args =

--- a/bin/periphery/src/api/build.rs
+++ b/bin/periphery/src/api/build.rs
@@ -91,11 +91,7 @@ impl Resolve<build::Build> for State {
     // Add VERSION to build args (if not already there)
     let mut build_args = environment_vars_from_str(build_args)
       .context("Invalid build_args")?;
-    if build_args
-      .iter()
-      .find(|a| a.variable == "VERSION")
-      .is_none()
-    {
+    if !build_args.iter().any(|a| a.variable == "VERSION") {
       build_args.push(EnvironmentVar {
         variable: String::from("VERSION"),
         value: build.config.version.to_string(),

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -88,12 +88,15 @@ impl Resolve<GetComposeServiceLog> for State {
       project,
       service,
       tail,
+      timestamps,
     }: GetComposeServiceLog,
     _: (),
   ) -> anyhow::Result<Log> {
     let docker_compose = docker_compose();
+    let timestamps =
+      timestamps.then_some(" --timestamps").unwrap_or_default();
     let command = format!(
-      "{docker_compose} -p {project} logs {service} --tail {tail}"
+      "{docker_compose} -p {project} logs {service} --tail {tail}{timestamps}"
     );
     Ok(run_komodo_command("get stack log", command).await)
   }
@@ -113,12 +116,15 @@ impl Resolve<GetComposeServiceLogSearch> for State {
       terms,
       combinator,
       invert,
+      timestamps,
     }: GetComposeServiceLogSearch,
     _: (),
   ) -> anyhow::Result<Log> {
     let docker_compose = docker_compose();
     let grep = log_grep(&terms, combinator, invert);
-    let command = format!("{docker_compose} -p {project} logs {service} --tail 5000 2>&1 | {grep}");
+    let timestamps =
+      timestamps.then_some(" --timestamps").unwrap_or_default();
+    let command = format!("{docker_compose} -p {project} logs {service} --tail 5000{timestamps} 2>&1 | {grep}");
     Ok(run_komodo_command("get stack log grep", command).await)
   }
 }

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -28,6 +28,7 @@ impl Resolve<ListComposeProjects, ()> for State {
     let docker_compose = docker_compose();
     let res = run_komodo_command(
       "list projects",
+      None,
       format!("{docker_compose} ls --all --format json"),
     )
     .await;
@@ -98,7 +99,7 @@ impl Resolve<GetComposeServiceLog> for State {
     let command = format!(
       "{docker_compose} -p {project} logs {service} --tail {tail}{timestamps}"
     );
-    Ok(run_komodo_command("get stack log", command).await)
+    Ok(run_komodo_command("get stack log", None, command).await)
   }
 }
 
@@ -125,7 +126,7 @@ impl Resolve<GetComposeServiceLogSearch> for State {
     let timestamps =
       timestamps.then_some(" --timestamps").unwrap_or_default();
     let command = format!("{docker_compose} -p {project} logs {service} --tail 5000{timestamps} 2>&1 | {grep}");
-    Ok(run_komodo_command("get stack log grep", command).await)
+    Ok(run_komodo_command("get stack log grep", None, command).await)
   }
 }
 
@@ -295,6 +296,7 @@ impl Resolve<ComposeExecution> for State {
     let docker_compose = docker_compose();
     let log = run_komodo_command(
       "compose command",
+      None,
       format!("{docker_compose} -p {project} {command}"),
     )
     .await;

--- a/bin/periphery/src/api/container.rs
+++ b/bin/periphery/src/api/container.rs
@@ -53,7 +53,7 @@ impl Resolve<GetContainerLog> for State {
       timestamps.then_some(" --timestamps").unwrap_or_default();
     let command =
       format!("docker logs {name} --tail {tail}{timestamps}");
-    Ok(run_komodo_command("get container log", command).await)
+    Ok(run_komodo_command("get container log", None, command).await)
   }
 }
 
@@ -82,7 +82,10 @@ impl Resolve<GetContainerLogSearch> for State {
     let command = format!(
       "docker logs {name} --tail 5000{timestamps} 2>&1 | {grep}"
     );
-    Ok(run_komodo_command("get container log grep", command).await)
+    Ok(
+      run_komodo_command("get container log grep", None, command)
+        .await,
+    )
   }
 }
 
@@ -137,6 +140,7 @@ impl Resolve<StartContainer> for State {
     Ok(
       run_komodo_command(
         "docker start",
+        None,
         format!("docker start {name}"),
       )
       .await,
@@ -156,6 +160,7 @@ impl Resolve<RestartContainer> for State {
     Ok(
       run_komodo_command(
         "docker restart",
+        None,
         format!("docker restart {name}"),
       )
       .await,
@@ -175,6 +180,7 @@ impl Resolve<PauseContainer> for State {
     Ok(
       run_komodo_command(
         "docker pause",
+        None,
         format!("docker pause {name}"),
       )
       .await,
@@ -192,6 +198,7 @@ impl Resolve<UnpauseContainer> for State {
     Ok(
       run_komodo_command(
         "docker unpause",
+        None,
         format!("docker unpause {name}"),
       )
       .await,
@@ -209,10 +216,11 @@ impl Resolve<StopContainer> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = stop_container_command(&name, signal, time);
-    let log = run_komodo_command("docker stop", command).await;
+    let log = run_komodo_command("docker stop", None, command).await;
     if log.stderr.contains("unknown flag: --signal") {
       let command = stop_container_command(&name, None, time);
-      let mut log = run_komodo_command("docker stop", command).await;
+      let mut log =
+        run_komodo_command("docker stop", None, command).await;
       log.stderr = format!(
         "old docker version: unable to use --signal flag{}",
         if !log.stderr.is_empty() {
@@ -241,12 +249,14 @@ impl Resolve<RemoveContainer> for State {
     let command =
       format!("{stop_command} && docker container rm {name}");
     let log =
-      run_komodo_command("docker stop and remove", command).await;
+      run_komodo_command("docker stop and remove", None, command)
+        .await;
     if log.stderr.contains("unknown flag: --signal") {
       let stop_command = stop_container_command(&name, None, time);
       let command =
         format!("{stop_command} && docker container rm {name}");
-      let mut log = run_komodo_command("docker stop", command).await;
+      let mut log =
+        run_komodo_command("docker stop", None, command).await;
       log.stderr = format!(
         "old docker version: unable to use --signal flag{}",
         if !log.stderr.is_empty() {
@@ -276,7 +286,7 @@ impl Resolve<RenameContainer> for State {
   ) -> anyhow::Result<Log> {
     let new = to_komodo_name(&new_name);
     let command = format!("docker rename {curr_name} {new}");
-    Ok(run_komodo_command("docker rename", command).await)
+    Ok(run_komodo_command("docker rename", None, command).await)
   }
 }
 
@@ -290,7 +300,7 @@ impl Resolve<PruneContainers> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = String::from("docker container prune -f");
-    Ok(run_komodo_command("prune containers", command).await)
+    Ok(run_komodo_command("prune containers", None, command).await)
   }
 }
 
@@ -308,14 +318,12 @@ impl Resolve<StartAllContainers> for State {
       .await
       .context("failed to list all containers on host")?;
     let futures =
-      containers.iter().map(
-        |ContainerListItem { name, .. }| {
-          let command = format!("docker start {name}");
-          async move {
-            run_komodo_command(&command.clone(), command).await
-          }
-        },
-      );
+      containers.iter().map(|ContainerListItem { name, .. }| {
+        let command = format!("docker start {name}");
+        async move {
+          run_komodo_command(&command.clone(), None, command).await
+        }
+      });
     Ok(join_all(futures).await)
   }
 }
@@ -333,14 +341,13 @@ impl Resolve<RestartAllContainers> for State {
       .list_containers()
       .await
       .context("failed to list all containers on host")?;
-    let futures = containers.iter().map(
-      |ContainerListItem { name, .. }| {
+    let futures =
+      containers.iter().map(|ContainerListItem { name, .. }| {
         let command = format!("docker restart {name}");
         async move {
-          run_komodo_command(&command.clone(), command).await
+          run_komodo_command(&command.clone(), None, command).await
         }
-      },
-    );
+      });
     Ok(join_all(futures).await)
   }
 }
@@ -358,14 +365,13 @@ impl Resolve<PauseAllContainers> for State {
       .list_containers()
       .await
       .context("failed to list all containers on host")?;
-    let futures = containers.iter().map(
-      |ContainerListItem { name, .. }| {
+    let futures =
+      containers.iter().map(|ContainerListItem { name, .. }| {
         let command = format!("docker pause {name}");
         async move {
-          run_komodo_command(&command.clone(), command).await
+          run_komodo_command(&command.clone(), None, command).await
         }
-      },
-    );
+      });
     Ok(join_all(futures).await)
   }
 }
@@ -383,14 +389,13 @@ impl Resolve<UnpauseAllContainers> for State {
       .list_containers()
       .await
       .context("failed to list all containers on host")?;
-    let futures = containers.iter().map(
-      |ContainerListItem { name, .. }| {
+    let futures =
+      containers.iter().map(|ContainerListItem { name, .. }| {
         let command = format!("docker unpause {name}");
         async move {
-          run_komodo_command(&command.clone(), command).await
+          run_komodo_command(&command.clone(), None, command).await
         }
-      },
-    );
+      });
     Ok(join_all(futures).await)
   }
 }
@@ -412,6 +417,7 @@ impl Resolve<StopAllContainers> for State {
       |ContainerListItem { name, .. }| async move {
         run_komodo_command(
           &format!("docker stop {name}"),
+          None,
           stop_container_command(name, None, None),
         )
         .await

--- a/bin/periphery/src/api/deploy.rs
+++ b/bin/periphery/src/api/deploy.rs
@@ -87,7 +87,7 @@ impl Resolve<Deploy> for State {
     debug!("docker run command: {command}");
 
     if deployment.config.skip_secret_interp {
-      Ok(run_komodo_command("docker run", command).await)
+      Ok(run_komodo_command("docker run", None, command).await)
     } else {
       let command = svi::interpolate_variables(
         &command,
@@ -107,7 +107,8 @@ impl Resolve<Deploy> for State {
       };
 
       replacers.extend(core_replacers);
-      let mut log = run_komodo_command("docker run", command).await;
+      let mut log =
+        run_komodo_command("docker run", None, command).await;
       log.command = svi::replace_in_string(&log.command, &replacers);
       log.stdout = svi::replace_in_string(&log.stdout, &replacers);
       log.stderr = svi::replace_in_string(&log.stderr, &replacers);

--- a/bin/periphery/src/api/image.rs
+++ b/bin/periphery/src/api/image.rs
@@ -44,7 +44,7 @@ impl Resolve<DeleteImage> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = format!("docker image rm {name}");
-    Ok(run_komodo_command("delete image", command).await)
+    Ok(run_komodo_command("delete image", None, command).await)
   }
 }
 
@@ -58,6 +58,6 @@ impl Resolve<PruneImages> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = String::from("docker image prune -a -f");
-    Ok(run_komodo_command("prune images", command).await)
+    Ok(run_komodo_command("prune images", None, command).await)
   }
 }

--- a/bin/periphery/src/api/mod.rs
+++ b/bin/periphery/src/api/mod.rs
@@ -255,7 +255,7 @@ impl Resolve<RunCommand> for State {
       } else {
         format!("cd {path} && {command}")
       };
-      run_komodo_command("run command", command).await
+      run_komodo_command("run command", None, command).await
     })
     .await
     .context("failure in spawned task")
@@ -270,6 +270,6 @@ impl Resolve<PruneSystem> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = String::from("docker system prune -a -f --volumes");
-    Ok(run_komodo_command("prune system", command).await)
+    Ok(run_komodo_command("prune system", None, command).await)
   }
 }

--- a/bin/periphery/src/api/network.rs
+++ b/bin/periphery/src/api/network.rs
@@ -34,7 +34,7 @@ impl Resolve<CreateNetwork> for State {
       None => String::new(),
     };
     let command = format!("docker network create{driver} {name}");
-    Ok(run_komodo_command("create network", command).await)
+    Ok(run_komodo_command("create network", None, command).await)
   }
 }
 
@@ -48,7 +48,7 @@ impl Resolve<DeleteNetwork> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = format!("docker network rm {name}");
-    Ok(run_komodo_command("delete network", command).await)
+    Ok(run_komodo_command("delete network", None, command).await)
   }
 }
 
@@ -62,6 +62,6 @@ impl Resolve<PruneNetworks> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = String::from("docker network prune -f");
-    Ok(run_komodo_command("prune networks", command).await)
+    Ok(run_komodo_command("prune networks", None, command).await)
   }
 }

--- a/bin/periphery/src/api/volume.rs
+++ b/bin/periphery/src/api/volume.rs
@@ -28,7 +28,7 @@ impl Resolve<DeleteVolume> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = format!("docker volume rm {name}");
-    Ok(run_komodo_command("delete volume", command).await)
+    Ok(run_komodo_command("delete volume", None, command).await)
   }
 }
 
@@ -42,6 +42,6 @@ impl Resolve<PruneVolumes> for State {
     _: (),
   ) -> anyhow::Result<Log> {
     let command = String::from("docker volume prune -a -f");
-    Ok(run_komodo_command("prune volumes", command).await)
+    Ok(run_komodo_command("prune volumes", None, command).await)
   }
 }

--- a/bin/periphery/src/docker.rs
+++ b/bin/periphery/src/docker.rs
@@ -935,7 +935,7 @@ pub async fn docker_login(
 #[instrument]
 pub async fn pull_image(image: &str) -> Log {
   let command = format!("docker pull {image}");
-  run_komodo_command("docker pull", command).await
+  run_komodo_command("docker pull", None, command).await
 }
 
 pub fn stop_container_command(

--- a/bin/periphery/src/helpers.rs
+++ b/bin/periphery/src/helpers.rs
@@ -66,3 +66,14 @@ pub fn log_grep(
     }
   }
 }
+
+pub fn interpolate_variables(
+  input: &str,
+) -> svi::Result<(String, Vec<(String, String)>)> {
+  svi::interpolate_variables(
+    input,
+    &periphery_config().secrets,
+    svi::Interpolator::DoubleBrackets,
+    true,
+  )
+}

--- a/client/core/rs/src/api/execute/stack.rs
+++ b/client/core/rs/src/api/execute/stack.rs
@@ -128,7 +128,7 @@ pub struct UnpauseStack {
 
 //
 
-/// Starts the target stack. `docker compose stop`. Response: [Update]
+/// Stops the target stack. `docker compose stop`. Response: [Update]
 #[typeshare]
 #[derive(
   Debug,

--- a/client/core/rs/src/api/read/deployment.rs
+++ b/client/core/rs/src/api/read/deployment.rs
@@ -120,6 +120,9 @@ pub struct GetDeploymentLog {
   /// Max: 5000.
   #[serde(default = "default_tail")]
   pub tail: U64,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 fn default_tail() -> u64 {
@@ -156,6 +159,9 @@ pub struct SearchDeploymentLog {
   /// Invert the results, ie return all lines that DON'T match the terms / combinator.
   #[serde(default)]
   pub invert: bool,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 #[typeshare]

--- a/client/core/rs/src/api/read/server.rs
+++ b/client/core/rs/src/api/read/server.rs
@@ -303,6 +303,9 @@ pub struct GetContainerLog {
   /// Max: 5000.
   #[serde(default = "default_tail")]
   pub tail: U64,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 fn default_tail() -> u64 {
@@ -341,6 +344,9 @@ pub struct SearchContainerLog {
   /// Invert the results, ie return all lines that DON'T match the terms / combinator.
   #[serde(default)]
   pub invert: bool,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 #[typeshare]

--- a/client/core/rs/src/api/read/stack.rs
+++ b/client/core/rs/src/api/read/stack.rs
@@ -69,6 +69,9 @@ pub struct GetStackServiceLog {
   /// Max: 5000.
   #[serde(default = "default_tail")]
   pub tail: U64,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 fn default_tail() -> u64 {
@@ -107,6 +110,9 @@ pub struct SearchStackServiceLog {
   /// Invert the results, ie return all lines that DON'T match the terms / combinator.
   #[serde(default)]
   pub invert: bool,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 #[typeshare]

--- a/client/core/rs/src/entities/mod.rs
+++ b/client/core/rs/src/entities/mod.rs
@@ -614,7 +614,7 @@ impl CloneArgs {
   pub fn path(&self, repo_dir: &Path) -> PathBuf {
     let path = match &self.destination {
       Some(destination) => PathBuf::from(&destination),
-      None => repo_dir.join(&to_komodo_name(&self.name)),
+      None => repo_dir.join(to_komodo_name(&self.name)),
     };
     path.components().collect::<PathBuf>()
   }
@@ -650,9 +650,7 @@ impl CloneArgs {
       .join(self.provider.replace('/', "-"))
       .join(repo.replace('/', "-"))
       .join(self.branch.replace('/', "-"))
-      .join(
-        self.commit.as_ref().map(String::as_str).unwrap_or("latest"),
-      );
+      .join(self.commit.as_deref().unwrap_or("latest"));
     Ok(res)
   }
 }

--- a/client/core/rs/src/entities/mod.rs
+++ b/client/core/rs/src/entities/mod.rs
@@ -219,7 +219,7 @@ impl SystemCommand {
   }
 
   pub fn is_none(&self) -> bool {
-    self.path.is_empty() || self.command.is_empty()
+    self.command.is_empty()
   }
 }
 

--- a/client/core/rs/src/entities/procedure.rs
+++ b/client/core/rs/src/entities/procedure.rs
@@ -104,7 +104,7 @@ pub struct ProcedureStage {
   #[serde(default = "default_enabled")]
   pub enabled: bool,
   /// The executions in the stage
-  #[serde(default)]
+  #[serde(default, alias = "execution")]
   pub executions: Vec<EnabledExecution>,
 }
 

--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -213,6 +213,11 @@ pub struct StackConfig {
   #[builder(default)]
   pub run_build: bool,
 
+  /// Whether to run `docker compose down` before `compose up`.
+  #[serde(default)]
+  #[builder(default)]
+  pub destroy_before_deploy: bool,
+
   /// Whether to skip secret interpolation into the stack environment variables.
   #[serde(default)]
   #[builder(default)]
@@ -426,6 +431,7 @@ impl Default for StackConfig {
       environment: Default::default(),
       env_file_path: default_env_file_path(),
       run_build: Default::default(),
+      destroy_before_deploy: Default::default(),
       build_extra_args: Default::default(),
       skip_secret_interp: Default::default(),
       git_provider: default_git_provider(),

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -2323,6 +2323,8 @@ export interface StackConfig {
 	 * Combine with build_extra_args for custom behaviors.
 	 */
 	run_build?: boolean;
+	/** Whether to run `docker compose down` before `compose up`. */
+	destroy_before_deploy?: boolean;
 	/** Whether to skip secret interpolation into the stack environment variables. */
 	skip_secret_interp?: boolean;
 	/**
@@ -3797,7 +3799,7 @@ export interface UnpauseStack {
 	service?: string;
 }
 
-/** Starts the target stack. `docker compose stop`. Response: [Update] */
+/** Stops the target stack. `docker compose stop`. Response: [Update] */
 export interface StopStack {
 	/** Id or name */
 	stack: string;

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -4114,6 +4114,8 @@ export interface GetDeploymentLog {
 	 * Max: 5000.
 	 */
 	tail: U64;
+	/** Enable `--timestamps` */
+	timestamps?: boolean;
 }
 
 export enum SearchCombinator {
@@ -4141,6 +4143,8 @@ export interface SearchDeploymentLog {
 	combinator?: SearchCombinator;
 	/** Invert the results, ie return all lines that DON'T match the terms / combinator. */
 	invert?: boolean;
+	/** Enable `--timestamps` */
+	timestamps?: boolean;
 }
 
 /**
@@ -4607,6 +4611,8 @@ export interface GetContainerLog {
 	 * Max: 5000.
 	 */
 	tail: U64;
+	/** Enable `--timestamps` */
+	timestamps?: boolean;
 }
 
 /**
@@ -4631,6 +4637,8 @@ export interface SearchContainerLog {
 	combinator?: SearchCombinator;
 	/** Invert the results, ie return all lines that DON'T match the terms / combinator. */
 	invert?: boolean;
+	/** Enable `--timestamps` */
+	timestamps?: boolean;
 }
 
 /** Inspect a docker container on the server. Response: [Container]. */
@@ -4821,6 +4829,8 @@ export interface GetStackServiceLog {
 	 * Max: 5000.
 	 */
 	tail: U64;
+	/** Enable `--timestamps` */
+	timestamps?: boolean;
 }
 
 /**
@@ -4845,6 +4855,8 @@ export interface SearchStackServiceLog {
 	combinator?: SearchCombinator;
 	/** Invert the results, ie return all lines that DON'T match the terms / combinator. */
 	invert?: boolean;
+	/** Enable `--timestamps` */
+	timestamps?: boolean;
 }
 
 /**

--- a/client/periphery/rs/src/api/compose.rs
+++ b/client/periphery/rs/src/api/compose.rs
@@ -44,9 +44,12 @@ pub struct GetComposeServiceLog {
   pub project: String,
   /// The service name
   pub service: String,
-  /// pass `--tail` for only recent log contents
+  /// Pass `--tail` for only recent log contents. Max of 5000
   #[serde(default = "default_tail")]
   pub tail: u64,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 fn default_tail() -> u64 {
@@ -72,6 +75,9 @@ pub struct GetComposeServiceLogSearch {
   /// Invert the search (search for everything not matching terms)
   #[serde(default)]
   pub invert: bool,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 //

--- a/client/periphery/rs/src/api/container.rs
+++ b/client/periphery/rs/src/api/container.rs
@@ -23,6 +23,9 @@ pub struct GetContainerLog {
   pub name: String,
   #[serde(default = "default_tail")]
   pub tail: u64,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 fn default_tail() -> u64 {
@@ -40,6 +43,9 @@ pub struct GetContainerLogSearch {
   pub combinator: SearchCombinator,
   #[serde(default)]
   pub invert: bool,
+  /// Enable `--timestamps`
+  #[serde(default)]
+  pub timestamps: bool,
 }
 
 //

--- a/frontend/src/components/config/util.tsx
+++ b/frontend/src/components/config/util.tsx
@@ -749,7 +749,7 @@ export const SystemCommand = ({
         />
       </div>
       <MonacoEditor
-        value={value?.command}
+        value={value?.command || "  # Add multiple commands on new lines. Supports comments."}
         language="shell"
         onValueChange={(command) => set({ ...(value || {}), command })}
         readOnly={disabled}

--- a/frontend/src/components/config/util.tsx
+++ b/frontend/src/components/config/util.tsx
@@ -749,7 +749,7 @@ export const SystemCommand = ({
         />
       </div>
       <MonacoEditor
-        value={value?.command || "  # Add multiple commands on new lines. Supports comments."}
+        value={value?.command || "  # Add multiple commands on new lines. Supports comments.\n  "}
         language="shell"
         onValueChange={(command) => set({ ...(value || {}), command })}
         readOnly={disabled}

--- a/frontend/src/components/resources/build/config.tsx
+++ b/frontend/src/components/resources/build/config.tsx
@@ -100,7 +100,7 @@ export const BuildConfig = ({
                   <ConfigInput
                     className="text-lg w-[200px]"
                     label="Version"
-                    description="Version the image tag using server (major.minor.patch)"
+                    description="Version the image with major.minor.patch. It can be interpolated using [[$VERSION]]."
                     placeholder="0.0.0"
                     value={version}
                     onChange={(version) => set({ version: version as any })}

--- a/frontend/src/components/resources/stack/config.tsx
+++ b/frontend/src/components/resources/stack/config.tsx
@@ -389,6 +389,17 @@ export const StackConfig = ({
           ),
       },
     },
+    {
+      label: "Destroy",
+      labelHidden: true,
+      components: {
+        run_build: {
+          label: "Destroy Before Deploy",
+          description:
+            "Ensure 'docker compose down' is run before redeploying the Stack.",
+        },
+      },
+    },
   ];
 
   if (mode === undefined) {

--- a/lib/command/src/lib.rs
+++ b/lib/command/src/lib.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use komodo_client::entities::{komodo_timestamp, update::Log};
 use run_command::{async_run_command, CommandOutput};
 
@@ -7,9 +9,15 @@ use run_command::{async_run_command, CommandOutput};
 /// Supports full line and end of line comments. See [parse_multiline_command].
 pub async fn run_komodo_command(
   stage: &str,
+  path: impl Into<Option<&Path>>,
   command: impl AsRef<str>,
 ) -> Log {
   let command = parse_multiline_command(command);
+  let command = if let Some(path) = path.into() {
+    format!("cd {} && {command}", path.display(),)
+  } else {
+    command
+  };
   let start_ts = komodo_timestamp();
   let output = async_run_command(&command).await;
   output_into_log(stage, command, start_ts, output)

--- a/lib/git/src/clone.rs
+++ b/lib/git/src/clone.rs
@@ -39,8 +39,7 @@ where
 {
   let args: CloneArgs = clone_args.into();
   let repo_dir = args.path(repo_dir);
-  let repo_url =
-    args.remote_url(access_token.as_ref().map(String::as_str))?;
+  let repo_url = args.remote_url(access_token.as_deref())?;
 
   let mut logs = clone_inner(
     &repo_url,

--- a/lib/git/src/clone.rs
+++ b/lib/git/src/clone.rs
@@ -115,7 +115,8 @@ where
         replacers.extend(core_replacers.to_owned());
         let mut on_clone_log = run_komodo_command(
           "on clone",
-          format!("cd {} && {full_command}", on_clone_path.display()),
+          on_clone_path.as_ref(),
+          full_command,
         )
         .await;
 
@@ -136,11 +137,8 @@ where
       } else {
         let on_clone_log = run_komodo_command(
           "on clone",
-          format!(
-            "cd {} && {}",
-            on_clone_path.display(),
-            command.command
-          ),
+          on_clone_path.as_ref(),
+          &command.command,
         )
         .await;
         tracing::debug!(
@@ -169,7 +167,8 @@ where
         replacers.extend(core_replacers.to_owned());
         let mut on_pull_log = run_komodo_command(
           "on pull",
-          format!("cd {} && {full_command}", on_pull_path.display()),
+          on_pull_path.as_ref(),
+          &full_command,
         )
         .await;
 
@@ -190,11 +189,8 @@ where
       } else {
         let on_pull_log = run_komodo_command(
           "on pull",
-          format!(
-            "cd {} && {}",
-            on_pull_path.display(),
-            command.command
-          ),
+          on_pull_path.as_ref(),
+          &command.command,
         )
         .await;
         tracing::debug!(
@@ -255,10 +251,8 @@ async fn clone_inner(
   if let Some(commit) = commit {
     let reset_log = run_komodo_command(
       "set commit",
-      format!(
-        "cd {} && git reset --hard {commit}",
-        destination.display()
-      ),
+      destination,
+      format!("git reset --hard {commit}",),
     )
     .await;
     logs.push(reset_log);

--- a/lib/git/src/pull.rs
+++ b/lib/git/src/pull.rs
@@ -39,8 +39,7 @@ where
   let args: CloneArgs = clone_args.into();
   let path = args.path(repo_dir);
   let path_display = path.display();
-  let repo_url =
-    args.remote_url(access_token.as_ref().map(String::as_str))?;
+  let repo_url = args.remote_url(access_token.as_deref())?;
 
   // Set remote url
   let mut set_remote = run_komodo_command(


### PR DESCRIPTION
- `DeployStack`: Only compose down if "Destroy Before Deploy" is enabled
- Add timestamps toggle to the logs
- Add build $VERSION to variables, and also pass VERSION as default --build-arg
- For fresh installs using `first_server`: a default Builder will also be created pointing to the Server
- All the commands (Stack `pre_deploy`, Build `pre_build`, Repo `on_pull`) support multiline shell and comments