### PR TITLE
Update docker.rs to allow http docker socket connection

### DIFF
--- a/bin/periphery/src/docker.rs
+++ b/bin/periphery/src/docker.rs
@@ -31,7 +31,8 @@ impl Default for DockerClient {
   fn default() -> DockerClient {
     DockerClient {
       docker: Docker::connect_with_local_defaults()
-        .expect("failed to connect to docker daemon"),
+        .or_else(|_| Docker::connect_with_http_defaults())
+        .expect("failed to connect to docker daemon with either local or HTTP defaults"),
     }
   }
 }

--- a/bin/periphery/src/docker.rs
+++ b/bin/periphery/src/docker.rs
@@ -30,9 +30,8 @@ pub struct DockerClient {
 impl Default for DockerClient {
   fn default() -> DockerClient {
     DockerClient {
-      docker: Docker::connect_with_local_defaults()
-        .or_else(|_| Docker::connect_with_http_defaults())
-        .expect("failed to connect to docker daemon with either local or HTTP defaults"),
+      docker: Docker::connect_with_defaults()
+        .expect("failed to connect to docker daemon"),
     }
   }
 }


### PR DESCRIPTION
Add or_else to allow attempt to connect to docker socket proxy via http if local connection fails, as per #87.

This was tested by adding env var DOCKER_HOST to the compose.env file (picked up by periphery container, which is run as a non-root user without the docker.sock volume defined), creating a new stack in Komodo (using redis image), then deploying. Deployment was successful, however the stack is marked as down in Komodo. I double-checked that the periphery agent is able to view running containers and the logs of those containers by exec-ing into the container and running the commands, so I am unsure where the issue lies.