### PR TITLE
feat: Add docs link to topbar

### DIFF
--- a/frontend/src/components/topbar.tsx
+++ b/frontend/src/components/topbar.tsx
@@ -64,21 +64,34 @@ export const Topbar = () => {
 
         {/* Shortcuts */}
         <div className="flex justify-end items-center gap-2">
-          <MobileDropdown />
-          <OmniSearch setOpen={setOmniOpen} className="lg:hidden" />
-          <Version />
-          <WsStatusIndicator />
-          <KeyboardShortcuts />
-          <TopbarAlerts />
-          <TopbarUpdates />
-          <ThemeToggle />
-          <Logout />
+          <MobileDropdown/>
+          <OmniSearch setOpen={setOmniOpen} className="lg:hidden"/>
+          <div className="flex gap-0">
+            <Docs/>
+            <Version/>
+          </div>
+          <WsStatusIndicator/>
+          <KeyboardShortcuts/>
+          <TopbarAlerts/>
+          <TopbarUpdates/>
+          <ThemeToggle/>
+          <Logout/>
         </div>
       </div>
       <OmniDialog open={omniOpen} setOpen={setOmniOpen} />
     </div>
   );
 };
+
+const Docs = () => (<a
+    href="https://komo.do/docs/intro"
+    target="_blank"
+    className="hidden lg:block"
+>
+  <Button variant="link" size="sm">
+    <div>Docs</div>
+  </Button>
+</a>);
 
 const Version = () => {
   const version = useRead("GetVersion", {}).data?.version;


### PR DESCRIPTION
Often when I'm in the UI I need to reference the docs but there is no quick way to access them. This PR adds a [Docs](https://komo.do/docs/intro) link in the topbar next to the Version. 

It follows the same media breakpoints as version so it's out of the way on smaller screen sizes. 