### PR TITLE
docs: Add development docs

### DIFF
--- a/.devcontainer/dev.compose.yaml
+++ b/.devcontainer/dev.compose.yaml
@@ -1,0 +1,33 @@
+services:
+  dev:
+    image: mcr.microsoft.com/devcontainers/rust:1-1-bullseye
+    volumes:
+      # Mount the root folder that contains .git
+      - ../:/workspace:cached
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /proc:/proc
+      - repos:/etc/komodo/repos
+      - stacks:/etc/komodo/stacks
+    command: sleep infinity
+    ports:
+      - "9121:9121"
+    environment:
+      KOMODO_FIRST_SERVER: http://localhost:8120
+      KOMODO_DATABASE_ADDRESS: db
+      KOMODO_ENABLE_NEW_USERS: true
+      KOMODO_LOCAL_AUTH: true
+      KOMODO_JWT_SECRET: a_random_secret
+    links:
+      - db
+    # ...
+
+  db:
+    extends:
+      file: ../test.compose.yaml
+      service: ferretdb
+
+volumes:
+  data:
+  repo-cache:
+  repos:
+  stacks:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,13 +14,13 @@
 	},
 
 	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
-	// "mounts": [
-	// 	{
-	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
-	// 		"target": "/usr/local/cargo",
-	// 		"type": "volume"
-	// 	}
-	// ]
+	"mounts": [
+		{
+			"source": "devcontainer-cargo-cache-${devcontainerId}",
+			"target": "/usr/local/cargo",
+			"type": "volume"
+		}
+	],
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Komodo",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	//"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+	"dockerComposeFile": ["dev.compose.yaml"],
+	"workspaceFolder": "/workspace",
+  	"service": "dev",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "18.18.0"
+		}
+	},
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		9121
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "./.devcontainer/postCreate.sh",
+
+	"runServices": [
+		"db"
+	]
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,13 @@
 	"dockerComposeFile": ["dev.compose.yaml"],
 	"workspaceFolder": "/workspace",
   	"service": "dev",
+	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "18.18.0"
+		},
+		"ghcr.io/devcontainers-community/features/deno:1": {
+
 		}
 	},
 
@@ -21,9 +25,6 @@
 			"type": "volume"
 		}
 	],
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cargo install typeshare-cli

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb",
+        "denoland.vscode-deno"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,165 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Core",
+            "command": "cargo",
+            "args": [
+                "run",
+                "-p",
+                "komodo_core",
+                "--release"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "KOMODO_CONFIG_PATH": "test.core.config.toml"
+                }
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Build Core",
+            "command": "cargo",
+            "args": [
+                "build",
+                "-p",
+                "komodo_core",
+                "--release"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "KOMODO_CONFIG_PATH": "test.core.config.toml"
+                }
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Run Periphery",
+            "command": "cargo",
+            "args": [
+                "run",
+                "-p",
+                "komodo_periphery",
+                "--release"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "KOMODO_CONFIG_PATH": "test.periphery.config.toml"
+                }
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Build Periphery",
+            "command": "cargo",
+            "args": [
+                "build",
+                "-p",
+                "komodo_periphery",
+                "--release"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "KOMODO_CONFIG_PATH": "test.periphery.config.toml"
+                }
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Run Backend",
+            "dependsOn": [
+                "Run Core",
+                "Run Periphery"
+            ],
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Build TS Client Types",
+            "type": "process",
+            "command": "node",
+            "args": [
+                "./client/core/ts/generate_types.mjs"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "Init TS Client",
+            "type": "shell",
+            "command": "yarn && yarn build && yarn link",
+            "options": {
+                "cwd": "${workspaceFolder}/client/core/ts",
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Init Frontend Client",
+            "type": "shell",
+            "command": "yarn link komodo_client && yarn install",
+            "options": {
+                "cwd": "${workspaceFolder}/frontend",
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Init Frontend",
+            "dependsOn": [
+                "Build TS Client Types",
+                "Init TS Client",
+                "Init Frontend Client"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build Frontend",
+            "type": "shell",
+            "command": "yarn build",
+            "options": {
+                "cwd": "${workspaceFolder}/frontend",
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Frontend",
+            "type": "shell",
+            "command": "yarn dev",
+            "options": {
+                "cwd": "${workspaceFolder}/frontend",
+            },
+            "dependsOn": ["Build Frontend"],
+            "problemMatcher": []
+        },
+        {
+            "label": "Init",
+            "dependsOn": [
+                "Build Core",
+                "Build Periphery",
+                "Init Frontend"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Komodo",
+            "dependsOn": [
+                "Run Core",
+                "Run Periphery",
+                "Run Frontend"
+            ],
+            "problemMatcher": []
+        },
+    ]
+  }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -134,22 +134,36 @@
             "problemMatcher": []
         },
         {
+            "label": "Prepare Frontend For Run",
+            "type": "shell",
+            "command": "cp -r ./client/core/ts/dist/. frontend/public/client/.",
+            "options": {
+                "cwd": "${workspaceFolder}",
+            },
+            "dependsOn": [
+                "Build TS Client Types",
+                "Build Frontend"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": []
+        },
+        {
             "label": "Run Frontend",
             "type": "shell",
             "command": "yarn dev",
             "options": {
                 "cwd": "${workspaceFolder}/frontend",
             },
-            "dependsOn": ["Build Frontend"],
+            "dependsOn": ["Prepare Frontend For Run"],
             "problemMatcher": []
         },
         {
             "label": "Init",
             "dependsOn": [
-                "Build Core",
-                "Build Periphery",
+                "Build Backend",
                 "Init Frontend"
             ],
+            "dependsOrder": "sequence",
             "problemMatcher": []
         },
         {

--- a/docsite/docs/development.md
+++ b/docsite/docs/development.md
@@ -17,9 +17,7 @@ Optionally, [runnables-cli](https://github.com/mbecker20/runnables-cli) can be u
 
 ## Docker
 
-(TBD adding a port to `test.compose.yaml`)
-
-After making changes to the project simply run `run test-compose-build` to rebuild Komodo and then `run test-compose` to start a Komodo container with the UI accessible at `localhost:9120`.
+After making changes to the project simply run `run test-compose-build` to rebuild Komodo and then `run test-compose-exposed` to start a Komodo container with the UI accessible at `localhost:9120`.
 
 ## Local and Docs
 

--- a/docsite/docs/development.md
+++ b/docsite/docs/development.md
@@ -1,0 +1,39 @@
+# Development
+
+## Dependencies
+
+Running Komodo from [source](https://github.com/mbecker20/komodo) requires either [Docker](https://www.docker.com/) or these dependencies installed:
+
+* For backend (Komodo core server, periphery)
+    * [Rust](https://www.rust-lang.org/) stable 1.81(?)
+* For frontend (Web UI)
+    * [Node](https://nodejs.org/en) > 18 + NPM
+        * [Yarn](https://yarnpkg.com/)
+
+Optionally, [runnables-cli](https://github.com/mbecker20/runnables-cli) can be used as a convience for running common project tasks (like a Makefile) found in `runfile.toml`. Otherwise, you can create your own project tasks by references the `cmd`s found in `runfile.toml`. All instructions below will use runnables-cli.
+
+## Docker
+
+(TBD adding a port to `test.compose.yaml`)
+
+After making changes to the project simply run `run test-compose-build` to rebuild Komodo and then `run test-compose` to start a Komodo container with the UI accessible at `localhost:9120`.
+
+## Local and Docs
+
+### Komodo
+
+To run a full Komodo instance run commands in this order:
+
+* `cargo build` -- builds core and periphery
+* `run test-core`
+* `run test-periphery`
+* `run gen-ts-types`
+* `run build-ts-client`
+* `run build-frontend`
+* `run start-fronted`
+
+(TBD specifying running only parts of Komodo or rebuild/restart after code iteration)
+
+### Docs
+
+Use `run docsite-start` to start the [Docusaurus](https://docusaurus.io/) Komodo docs site in development mode. Changes made to files in `/docsite` will be automatically reloaded by the server.

--- a/docsite/docs/development.md
+++ b/docsite/docs/development.md
@@ -12,6 +12,7 @@ Running Komodo from [source](https://github.com/mbecker20/komodo) requires eithe
     * [Node](https://nodejs.org/en) >= 18.18 + NPM
         * [Yarn](https://yarnpkg.com/)
     * [typeshare](https://github.com/1password/typeshare)
+    * [Deno](https://deno.com/) >= 2.0.2
 
 ## Docker
 
@@ -37,7 +38,7 @@ To run a full Komodo instance from a non-container environment run commands in t
     * `run test-core` -- builds core binary
     * `run test-periphery` -- builds periphery binary
 * Build Frontend
-    * `run gen-ts-types` -- generates types for use with building typescript client
+    * `run gen-client` -- generates TS client and adds to the frontend
     * Prepare API Client
         * `cd client/core/ts && yarn && yarn build && yarn link`
             * After running once client can be rebuilt with `run build-ts-client`

--- a/docsite/docs/development.md
+++ b/docsite/docs/development.md
@@ -4,11 +4,14 @@
 
 Running Komodo from [source](https://github.com/mbecker20/komodo) requires either [Docker](https://www.docker.com/) or these dependencies installed:
 
-* For backend (Komodo core server, periphery)
-    * [Rust](https://www.rust-lang.org/) stable 1.81(?)
+* For backend (Komodo core server, periphery, API)
+    * [Rust](https://www.rust-lang.org/) stable 1.81
+    * [rustup](https://rustup.rs/)
+    * [MongoDB](https://www.mongodb.com/) compatible database
 * For frontend (Web UI)
-    * [Node](https://nodejs.org/en) > 18 + NPM
+    * [Node](https://nodejs.org/en) >= 18.18 + NPM
         * [Yarn](https://yarnpkg.com/)
+    * [typeshare](https://github.com/1password/typeshare)
 
 Optionally, [runnables-cli](https://github.com/mbecker20/runnables-cli) can be used as a convience for running common project tasks (like a Makefile) found in `runfile.toml`. Otherwise, you can create your own project tasks by references the `cmd`s found in `runfile.toml`. All instructions below will use runnables-cli.
 
@@ -24,15 +27,20 @@ After making changes to the project simply run `run test-compose-build` to rebui
 
 To run a full Komodo instance run commands in this order:
 
-* `cargo build` -- builds core and periphery
-* `run test-core`
-* `run test-periphery`
-* `run gen-ts-types`
-* `run build-ts-client`
-* `run build-frontend`
-* `run start-fronted`
-
-(TBD specifying running only parts of Komodo or rebuild/restart after code iteration)
+* Ensure dependencies are up to date
+    * `rustup update` -- ensure rust toolchain is up to date
+* Build backend
+    * `cargo build` -- builds core and periphery
+    * `run test-core` -- builds core binary
+    * `run test-periphery` -- builds periphery binary
+* Build Frontend
+    * `run gen-ts-types` -- generates types for use with building typescript client
+    * Prepare API Client
+        * `cd client/core/ts && yarn && yarn build && yarn link`
+            * After running once client can be rebuilt with `run build-ts-client`
+    * [Prepare Frontend](/frontend//README.md)
+        * `cd frontend && yarn link komodo_client && yarn install`
+            * After running once client can be built with `run build-frontend` or started in dev (watch) mode with `run start-frontend`
 
 ### Docs
 

--- a/docsite/docs/development.md
+++ b/docsite/docs/development.md
@@ -2,7 +2,7 @@
 
 ## Dependencies
 
-Running Komodo from [source](https://github.com/mbecker20/komodo) requires either [Docker](https://www.docker.com/) or these dependencies installed:
+Running Komodo from [source](https://github.com/mbecker20/komodo) requires either [Docker](https://www.docker.com/), use of the included [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) or these dependencies installed:
 
 * For backend (Komodo core server, periphery, API)
     * [Rust](https://www.rust-lang.org/) stable 1.81
@@ -13,22 +13,27 @@ Running Komodo from [source](https://github.com/mbecker20/komodo) requires eithe
         * [Yarn](https://yarnpkg.com/)
     * [typeshare](https://github.com/1password/typeshare)
 
-Optionally, [runnables-cli](https://github.com/mbecker20/runnables-cli) can be used as a convience for running common project tasks (like a Makefile) found in `runfile.toml`. Otherwise, you can create your own project tasks by references the `cmd`s found in `runfile.toml`. All instructions below will use runnables-cli.
-
 ## Docker
 
-After making changes to the project simply run `run test-compose-build` to rebuild Komodo and then `run test-compose-exposed` to start a Komodo container with the UI accessible at `localhost:9120`.
+After making changes to the project simply run `run test-compose-build` to rebuild Komodo and then `run test-compose-exposed` to start a Komodo container with the UI accessible at `localhost:9120`. Any changes made to source files will require re-running the build and exposed commands.
 
-## Local and Docs
+## Devcontainer
 
-### Komodo
+Use the included `.devcontainer.json` with VSCode or other compatible IDE to stand-up a full environment, including database, with one click.
 
-To run a full Komodo instance run commands in this order:
+[VSCode Tasks](https://code.visualstudio.com/Docs/editor/tasks) are provded for building and running Komodo. 
+
+After opening the repository with the devcontainer run the task `Init` to build the frontend/backend. Then, the task `Run Komodo` can be used to run frontend/backend. Other tasks for rebuilding/running only parts of the application are also provided.
+
+## Local
+
+[runnables-cli](https://github.com/mbecker20/runnables-cli) can be used as a convience for running common project tasks (like a Makefile) found in `runfile.toml`. Otherwise, you can create your own project tasks by references the `cmd`s found in `runfile.toml`. All instructions below will use runnables-cli.
+
+To run a full Komodo instance from a non-container environment run commands in this order:
 
 * Ensure dependencies are up to date
     * `rustup update` -- ensure rust toolchain is up to date
-* Build backend
-    * `cargo build` -- builds core and periphery
+* Build and Run backend
     * `run test-core` -- builds core binary
     * `run test-periphery` -- builds periphery binary
 * Build Frontend

--- a/docsite/sidebars.ts
+++ b/docsite/sidebars.ts
@@ -63,6 +63,7 @@ const sidebars: SidebarsConfig = {
     "permissioning",
     "version-upgrades",
     "api",
+    "development"
   ],
 };
 

--- a/expose.compose.yaml
+++ b/expose.compose.yaml
@@ -1,0 +1,6 @@
+services:
+  core:
+    ports:
+      - 9120:9120
+    environment:
+      KOMODO_FIRST_SERVER: http://periphery:8120

--- a/runfile.toml
+++ b/runfile.toml
@@ -24,6 +24,12 @@ cmd = """
 docker compose -p komodo-dev -f test.compose.yaml down --remove-orphans && \
 docker compose -p komodo-dev -f test.compose.yaml up -d"""
 
+[test-compose-exposed]
+description = "deploys test.compose.yaml with exposed port and non-ssl periphery"
+cmd = """
+docker compose -p komodo-dev -f test.compose.yaml -f expose.compose.yaml down --remove-orphans && \
+docker compose -p komodo-dev -f test.compose.yaml -f expose.compose.yaml up -d"""
+
 [test-compose-build]
 description = "builds and deploys test.compose.yaml"
 cmd = """


### PR DESCRIPTION
This is a WIP for a jumping off point for users trying to develop or contribute to Komodo. The doc I've added is missing a few things and I had a few questions about dependencies and modifying test files:

- [x] `cargo build` with rust stable fails

On my machine (Arch kernel 6.10.9) Trying to run `cargo build` with Rust 1.81 (stable) I get a build error:

```
error: package `aws-sdk-sso v1.45.0` cannot be built because it requires rustc 1.78.0 or newer, while the currently active rustc version is 1.75.0
Either upgrade to rustc 1.78.0 or newer, or use
cargo update aws-sdk-sso@1.45.0 --precise ver
where `ver` is the latest version of `aws-sdk-sso` supporting rustc 1.75.0
```

Are you developing with nightly/unstable Rust? I did not see anything specific in the repo about what Rust version is required.

- [x] UI port for docker testing/development

There is no port exposed in [`test.compose.yaml`](https://github.com/FoxxMD/komodo/blob/0dcffbe9a979055e56c3111dc63734b66f37d278/test.compose.yaml). I imagine this is because it is currently used just to test that the container starts up without error? And exposing the default port might conflict with your existing local (non-docker) instance or something else happening on the komodo build runner.

Easiest change would be to just expose the port but another option would be to use a [service profile](https://docs.docker.com/compose/how-tos/profiles/) and add an additional `core-ui` service with exposed port. This would allow existing behavior to be unchanged but users could run `docker compose -p komodo-dev -f test.compose.yaml --profile ui up -d` to get the service with the port exposed. This would make testing docker builds for UI changes easier without any manual editing of compose files on the users part. Thoughts?

- [x] Order and run requirements for komodo

In the **Local and Docs** section it lists the `run` commands required to get a full Komodo instance up and running. Is the order of these commands correct?

If a user only wants to develop for one part of Komodo (lets say core) can they simply re-build/run one part while leaving everything else up? If so, what are the correct commands/order to rebuild/run for each of these:

* core
* periphery
* core/periphery
* frontend

- [x] vscode `tasks.json`

I realize you are using `runnables-cli` but since the repo is configured for vscode already you would consider also supporting [`tasks.json`](https://code.visualstudio.com/Docs/editor/tasks) to mirror `runfile.toml` so users don't need to install another dependency? If so I can try to get this implemented with the current runfile.