### PR TITLE
1.16.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "alerter"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "command"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "komodo_client",
  "run_command",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "environment_file"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "thiserror",
 ]
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "formatting"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "serror",
 ]
@@ -1571,7 +1571,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "command",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_cli"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_client"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_core"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_periphery"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -3090,7 +3090,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "periphery_client"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -4865,7 +4865,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update_logger"
-version = "1.16.5"
+version = "1.16.6"
 dependencies = [
  "anyhow",
  "komodo_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.16.5"
+version = "1.16.6"
 edition = "2021"
 authors = ["mbecker20 <becker.maxh@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/bin/core/src/api/execute/build.rs
+++ b/bin/core/src/api/execute/build.rs
@@ -459,7 +459,6 @@ async fn handle_early_return(
   Ok(update)
 }
 
-#[instrument(skip_all)]
 pub async fn validate_cancel_build(
   request: &ExecuteRequest,
 ) -> anyhow::Result<()> {

--- a/bin/core/src/api/read/mod.rs
+++ b/bin/core/src/api/read/mod.rs
@@ -339,6 +339,7 @@ impl Resolve<ListSecrets, User> for State {
         ResourceTarget::Server(id) => Some(id),
         ResourceTarget::Builder(id) => {
           match resource::get::<Builder>(&id).await?.config {
+            BuilderConfig::Url(_) => None,
             BuilderConfig::Server(config) => Some(config.server_id),
             BuilderConfig::Aws(config) => {
               secrets.extend(config.secrets);
@@ -387,6 +388,7 @@ impl Resolve<ListGitProvidersFromConfig, User> for State {
         }
         ResourceTarget::Builder(id) => {
           match resource::get::<Builder>(&id).await?.config {
+            BuilderConfig::Url(_) => {}
             BuilderConfig::Server(config) => {
               merge_git_providers_for_server(
                 &mut providers,
@@ -485,6 +487,7 @@ impl Resolve<ListDockerRegistriesFromConfig, User> for State {
         }
         ResourceTarget::Builder(id) => {
           match resource::get::<Builder>(&id).await?.config {
+            BuilderConfig::Url(_) => {}
             BuilderConfig::Server(config) => {
               merge_docker_registries_for_server(
                 &mut registries,

--- a/bin/core/src/helpers/query.rs
+++ b/bin/core/src/helpers/query.rs
@@ -118,7 +118,7 @@ pub fn get_stack_state_from_containers(
   if containers.is_empty() {
     return StackState::Down;
   }
-  if services.len() != containers.len() {
+  if services.len() > containers.len() {
     return StackState::Unhealthy;
   }
   let running = containers.iter().all(|container| {

--- a/bin/core/src/resource/builder.rs
+++ b/bin/core/src/resource/builder.rs
@@ -40,6 +40,9 @@ impl super::KomodoResource for Builder {
     builder: Resource<Self::Config, Self::Info>,
   ) -> Self::ListItem {
     let (builder_type, instance_type) = match builder.config {
+      BuilderConfig::Url(_) => {
+        (BuilderConfigVariant::Url.to_string(), None)
+      }
       BuilderConfig::Server(config) => (
         BuilderConfigVariant::Server.to_string(),
         Some(config.server_id),

--- a/bin/core/src/resource/server.rs
+++ b/bin/core/src/resource/server.rs
@@ -47,6 +47,7 @@ impl super::KomodoResource for Server {
       info: ServerListItemInfo {
         state: status.map(|s| s.state).unwrap_or_default(),
         region: server.config.region,
+        address: server.config.address,
         send_unreachable_alerts: server
           .config
           .send_unreachable_alerts,

--- a/bin/core/src/sync/toml.rs
+++ b/bin/core/src/sync/toml.rs
@@ -390,6 +390,7 @@ impl ToToml for Builder {
     let empty_params = match resource.config {
       PartialBuilderConfig::Aws(config) => config.is_none(),
       PartialBuilderConfig::Server(config) => config.is_none(),
+      PartialBuilderConfig::Url(config) => config.is_none(),
     };
     if empty_params {
       // toml_pretty will remove empty map

--- a/client/core/rs/src/deserializers/maybe_string_i64.rs
+++ b/client/core/rs/src/deserializers/maybe_string_i64.rs
@@ -1,0 +1,213 @@
+use serde::{de::Visitor, Deserializer};
+
+pub fn maybe_string_i64_deserializer<'de, D>(
+  deserializer: D,
+) -> Result<i64, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  deserializer.deserialize_any(MaybeStringI64Visitor)
+}
+
+pub fn option_maybe_string_i64_deserializer<'de, D>(
+  deserializer: D,
+) -> Result<Option<i64>, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  deserializer.deserialize_any(OptionMaybeStringI64Visitor)
+}
+
+struct MaybeStringI64Visitor;
+
+impl<'de> Visitor<'de> for MaybeStringI64Visitor {
+  type Value = i64;
+
+  fn expecting(
+    &self,
+    formatter: &mut std::fmt::Formatter,
+  ) -> std::fmt::Result {
+    write!(formatter, "number or string number")
+  }
+
+  fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    v.parse::<i64>().map_err(E::custom)
+  }
+
+  fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+
+  fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+
+  fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+
+  fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+
+  fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+
+  fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v)
+  }
+
+  fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+
+  fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+
+  fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+
+  fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v as i64)
+  }
+}
+
+struct OptionMaybeStringI64Visitor;
+
+impl<'de> Visitor<'de> for OptionMaybeStringI64Visitor {
+  type Value = Option<i64>;
+
+  fn expecting(
+    &self,
+    formatter: &mut std::fmt::Formatter,
+  ) -> std::fmt::Result {
+    write!(formatter, "null or number or string number")
+  }
+
+  fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    MaybeStringI64Visitor.visit_str(v).map(Some)
+  }
+
+  fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v))
+  }
+
+  fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(Some(v as i64))
+  }
+
+  fn visit_none<E>(self) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(None)
+  }
+
+  fn visit_unit<E>(self) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(None)
+  }
+}

--- a/client/core/rs/src/deserializers/mod.rs
+++ b/client/core/rs/src/deserializers/mod.rs
@@ -6,6 +6,7 @@ mod file_contents;
 mod labels;
 mod string_list;
 mod term_signal_labels;
+mod maybe_string_i64;
 
 pub use conversion::*;
 pub use environment::*;
@@ -13,3 +14,4 @@ pub use file_contents::*;
 pub use labels::*;
 pub use string_list::*;
 pub use term_signal_labels::*;
+pub use maybe_string_i64::*;

--- a/client/core/rs/src/entities/server.rs
+++ b/client/core/rs/src/entities/server.rs
@@ -27,6 +27,8 @@ pub struct ServerListItemInfo {
   pub state: ServerState,
   /// Region of the server.
   pub region: String,
+  /// Address of the server.
+  pub address: String,
   /// Whether server is configured to send unreachable alerts.
   pub send_unreachable_alerts: bool,
   /// Whether server is configured to send cpu alerts.

--- a/client/core/rs/src/entities/server_template/aws.rs
+++ b/client/core/rs/src/entities/server_template/aws.rs
@@ -127,7 +127,7 @@ apt upgrade -y
 curl -fsSL https://get.docker.com | sh
 systemctl enable docker.service
 systemctl enable containerd.service
-curl -sSL https://raw.githubusercontent.com/mbecker20/komodo/main/scripts/setup-periphery.py | python3
+curl -sSL https://raw.githubusercontent.com/mbecker20/komodo/main/scripts/setup-periphery.py | HOME=/root python3
 systemctl enable periphery.service")
 }
 

--- a/client/core/rs/src/entities/server_template/hetzner.rs
+++ b/client/core/rs/src/entities/server_template/hetzner.rs
@@ -121,7 +121,7 @@ runcmd:
   - curl -fsSL https://get.docker.com | sh
   - systemctl enable docker.service
   - systemctl enable containerd.service
-  - curl -sSL 'https://raw.githubusercontent.com/mbecker20/komodo/main/scripts/setup-periphery.py' | python3
+  - curl -sSL 'https://raw.githubusercontent.com/mbecker20/komodo/main/scripts/setup-periphery.py' | HOME=/root python3
   - systemctl enable periphery.service")
 }
 

--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -11,6 +11,7 @@ use typeshare::typeshare;
 use crate::deserializers::{
   env_vars_deserializer, file_contents_deserializer,
   option_env_vars_deserializer, option_file_contents_deserializer,
+  option_maybe_string_i64_deserializer,
   option_string_list_deserializer, string_list_deserializer,
 };
 
@@ -563,8 +564,8 @@ impl super::resource::AddFilters for StackQuerySpecifics {
   }
 }
 
-/// Keeping this minimal for now as its only needed to parse the service names / container names
-#[typeshare]
+/// Keeping this minimal for now as its only needed to parse the service names / container names,
+/// and replica count. Not a typeshared type.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ComposeFile {
   /// If not provided, will default to the parent folder holding the compose file.
@@ -573,9 +574,18 @@ pub struct ComposeFile {
   pub services: HashMap<String, ComposeService>,
 }
 
-#[typeshare]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ComposeService {
   pub image: Option<String>,
   pub container_name: Option<String>,
+  pub deploy: Option<ComposeServiceDeploy>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ComposeServiceDeploy {
+  #[serde(
+    default,
+    deserialize_with = "option_maybe_string_i64_deserializer"
+  )]
+  pub replicas: Option<i64>,
 }

--- a/client/core/ts/package.json
+++ b/client/core/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komodo_client",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "description": "Komodo client package",
   "homepage": "https://komo.do",
   "main": "dist/lib.js",

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -395,9 +395,11 @@ export interface BuildQuerySpecifics {
 export type BuildQuery = ResourceQuery<BuildQuerySpecifics>;
 
 export type BuilderConfig = 
-	/** Use a connected server an image builder. */
+	/** Use a Periphery address as a Builder. */
+	| { type: "Url", params: UrlBuilderConfig }
+	/** Use a connected server as a Builder. */
 	| { type: "Server", params: ServerBuilderConfig }
-	/** Use EC2 instances spawned on demand as an image builder. */
+	/** Use EC2 instances spawned on demand as a Builder. */
 	| { type: "Aws", params: AwsBuilderConfig };
 
 export type Builder = Resource<BuilderConfig, undefined>;
@@ -3406,6 +3408,8 @@ export type _PartialStackConfig = Partial<StackConfig>;
 
 export type _PartialTag = Partial<Tag>;
 
+export type _PartialUrlBuilderConfig = Partial<UrlBuilderConfig>;
+
 export interface __Serror {
 	error: string;
 	trace: string[];
@@ -4010,6 +4014,7 @@ export interface CreateBuildWebhook {
 
 /** Partial representation of [BuilderConfig] */
 export type PartialBuilderConfig = 
+	| { type: "Url", params: _PartialUrlBuilderConfig }
 	| { type: "Server", params: _PartialServerBuilderConfig }
 	| { type: "Aws", params: _PartialAwsBuilderConfig };
 
@@ -7174,6 +7179,14 @@ export interface UpdateVariableValue {
 	name: string;
 	/** The value to set. */
 	value: string;
+}
+
+/** Configuration for a Komodo Url Builder. */
+export interface UrlBuilderConfig {
+	/** The address of Periphery */
+	address: string;
+	/** A custom passkey to use. Otherwise, use the default passkey. */
+	passkey: string;
 }
 
 /** Update file contents in Files on Server or Git Repo mode. Response: [Update]. */

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -3159,6 +3159,8 @@ export interface ServerListItemInfo {
 	state: ServerState;
 	/** Region of the server. */
 	region: string;
+	/** Address of the server. */
+	address: string;
 	/** Whether server is configured to send unreachable alerts. */
 	send_unreachable_alerts: boolean;
 	/** Whether server is configured to send cpu alerts. */

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -3814,18 +3814,6 @@ export interface CommitSync {
 	sync: string;
 }
 
-export interface ComposeService {
-	image?: string;
-	container_name?: string;
-}
-
-/** Keeping this minimal for now as its only needed to parse the service names / container names */
-export interface ComposeFile {
-	/** If not provided, will default to the parent folder holding the compose file. */
-	name?: string;
-	services?: Record<string, ComposeService>;
-}
-
 export interface Conversion {
 	/** reference on the server. */
 	local: string;

--- a/docsite/docs/build-images/builders.md
+++ b/docsite/docs/build-images/builders.md
@@ -22,7 +22,7 @@ apt upgrade -y
 curl -fsSL https://get.docker.com | sh
 systemctl enable docker.service
 systemctl enable containerd.service
-curl -sSL https://raw.githubusercontent.com/mbecker20/komodo/main/scripts/setup-periphery.py | python3
+curl -sSL https://raw.githubusercontent.com/mbecker20/komodo/main/scripts/setup-periphery.py | HOME=/root python3
 systemctl enable periphery.service
 ```
 

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -3090,6 +3090,8 @@ export interface ServerListItemInfo {
     state: ServerState;
     /** Region of the server. */
     region: string;
+    /** Address of the server. */
+    address: string;
     /** Whether server is configured to send unreachable alerts. */
     send_unreachable_alerts: boolean;
     /** Whether server is configured to send cpu alerts. */

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -391,12 +391,17 @@ export interface BuildQuerySpecifics {
 }
 export type BuildQuery = ResourceQuery<BuildQuerySpecifics>;
 export type BuilderConfig = 
-/** Use a connected server an image builder. */
+/** Use a Periphery address as a Builder. */
 {
+    type: "Url";
+    params: UrlBuilderConfig;
+}
+/** Use a connected server as a Builder. */
+ | {
     type: "Server";
     params: ServerBuilderConfig;
 }
-/** Use EC2 instances spawned on demand as an image builder. */
+/** Use EC2 instances spawned on demand as a Builder. */
  | {
     type: "Aws";
     params: AwsBuilderConfig;
@@ -3270,6 +3275,7 @@ export type _PartialServerBuilderConfig = Partial<ServerBuilderConfig>;
 export type _PartialServerConfig = Partial<ServerConfig>;
 export type _PartialStackConfig = Partial<StackConfig>;
 export type _PartialTag = Partial<Tag>;
+export type _PartialUrlBuilderConfig = Partial<UrlBuilderConfig>;
 export interface __Serror {
     error: string;
     trace: string[];
@@ -3830,6 +3836,9 @@ export interface CreateBuildWebhook {
 }
 /** Partial representation of [BuilderConfig] */
 export type PartialBuilderConfig = {
+    type: "Url";
+    params: _PartialUrlBuilderConfig;
+} | {
     type: "Server";
     params: _PartialServerBuilderConfig;
 } | {
@@ -6690,6 +6699,13 @@ export interface UpdateVariableValue {
     name: string;
     /** The value to set. */
     value: string;
+}
+/** Configuration for a Komodo Url Builder. */
+export interface UrlBuilderConfig {
+    /** The address of Periphery */
+    address: string;
+    /** A custom passkey to use. Otherwise, use the default passkey. */
+    passkey: string;
 }
 /** Update file contents in Files on Server or Git Repo mode. Response: [Update]. */
 export interface WriteStackFileContents {

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -3652,16 +3652,6 @@ export interface CommitSync {
     /** Id or name */
     sync: string;
 }
-export interface ComposeService {
-    image?: string;
-    container_name?: string;
-}
-/** Keeping this minimal for now as its only needed to parse the service names / container names */
-export interface ComposeFile {
-    /** If not provided, will default to the parent folder holding the compose file. */
-    name?: string;
-    services?: Record<string, ComposeService>;
-}
 export interface Conversion {
     /** reference on the server. */
     local: string;

--- a/frontend/src/components/layouts.tsx
+++ b/frontend/src/components/layouts.tsx
@@ -184,7 +184,7 @@ export const Section = ({
     {(title || icon || titleRight || titleOther || actions) && (
       <div
         className={cn(
-          "flex flex-wrap gap-2 justify-between py-1",
+          "flex flex-wrap gap-2 justify-between",
           itemsCenterTitleRow ? "items-center" : "items-start"
         )}
       >

--- a/frontend/src/components/layouts.tsx
+++ b/frontend/src/components/layouts.tsx
@@ -36,7 +36,7 @@ export const Layout = () => {
       <div className="h-screen overflow-y-scroll">
         <div className="container">
           <Sidebar />
-          <div className="lg:ml-64 lg:pl-8 py-24">
+          <div className="lg:ml-[200px] lg:pl-8 py-[88px]">
             <Outlet />
           </div>
         </div>

--- a/frontend/src/components/resources/builder/config.tsx
+++ b/frontend/src/components/resources/builder/config.tsx
@@ -22,6 +22,7 @@ export const BuilderConfig = ({ id }: { id: string }) => {
   const config = useRead("GetBuilder", { builder: id }).data?.config;
   if (config?.type === "Aws") return <AwsBuilderConfig id={id} />;
   if (config?.type === "Server") return <ServerBuilderConfig id={id} />;
+  if (config?.type === "Url") return <UrlBuilderConfig id={id} />;
 };
 
 const AwsBuilderConfig = ({ id }: { id: string }) => {
@@ -292,6 +293,51 @@ const ServerBuilderConfig = ({ id }: { id: string }) => {
                     />
                   </ConfigItem>
                 );
+              },
+            },
+          },
+        ],
+      }}
+    />
+  );
+};
+
+const UrlBuilderConfig = ({ id }: { id: string }) => {
+  const perms = useRead("GetPermissionLevel", {
+    target: { type: "Builder", id },
+  }).data;
+  const config = useRead("GetBuilder", { builder: id }).data?.config;
+  const [update, set] = useLocalStorage<Partial<Types.UrlBuilderConfig>>(
+    `url-builder-${id}-update-v1`,
+    {}
+  );
+  const { mutateAsync } = useWrite("UpdateBuilder");
+  if (!config) return null;
+
+  const disabled = perms !== Types.PermissionLevel.Write;
+
+  return (
+    <Config
+      disabled={disabled}
+      config={config.params as Types.UrlBuilderConfig}
+      update={update}
+      set={set}
+      onSave={async () => {
+        await mutateAsync({ id, config: { type: "Url", params: update } });
+      }}
+      components={{
+        "": [
+          {
+            label: "General",
+            labelHidden: true,
+            components: {
+              address: {
+                description: "The address of the Periphery agent",
+                placeholder: "https://periphery:8120",
+              },
+              passkey: {
+                description: "Use a custom passkey to authenticate with Periphery",
+                placeholder: "Custom passkey",
               },
             },
           },

--- a/frontend/src/components/resources/builder/index.tsx
+++ b/frontend/src/components/resources/builder/index.tsx
@@ -104,6 +104,7 @@ export const BuilderComponents: RequiredResourceComponents = {
               <SelectGroup>
                 <SelectItem value="Aws">Aws</SelectItem>
                 <SelectItem value="Server">Server</SelectItem>
+                <SelectItem value="Url">Url</SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>

--- a/frontend/src/components/resources/server/info/containers.tsx
+++ b/frontend/src/components/resources/server/info/containers.tsx
@@ -1,14 +1,13 @@
 import { DockerContainersSection } from "@components/util";
 import { useRead } from "@lib/hooks";
+import { ReactNode } from "react";
 
 export const Containers = ({
   id,
-  show,
-  setShow,
+  titleOther
 }: {
   id: string;
-  show: boolean;
-  setShow: (show: boolean) => void;
+  titleOther: ReactNode
 }) => {
   const containers =
     useRead("ListDockerContainers", { server: id }, { refetchInterval: 10_000 })
@@ -17,8 +16,7 @@ export const Containers = ({
     <DockerContainersSection
       server_id={id}
       containers={containers}
-      show={show}
-      setShow={setShow}
+      titleOther={titleOther}
       pruneButton
     />
   );

--- a/frontend/src/components/resources/server/info/images.tsx
+++ b/frontend/src/components/resources/server/info/images.tsx
@@ -5,6 +5,7 @@ import { useRead } from "@lib/hooks";
 import { Badge } from "@ui/badge";
 import { DataTable, SortableHeader } from "@ui/data-table";
 import { ReactNode } from "react";
+import { Prune } from "../actions";
 
 export const Images = ({
   id,
@@ -17,8 +18,13 @@ export const Images = ({
     useRead("ListDockerImages", { server: id }, { refetchInterval: 10_000 })
       .data ?? [];
 
+  const allInUse = images.every((image) => image.in_use);
+
   return (
-    <Section titleOther={titleOther}>
+    <Section
+      titleOther={titleOther}
+      actions={!allInUse && <Prune server_id={id} type="Images" />}
+    >
       <DataTable
         tableKey="server-images"
         data={images}

--- a/frontend/src/components/resources/server/info/images.tsx
+++ b/frontend/src/components/resources/server/info/images.tsx
@@ -1,84 +1,66 @@
 import { Section } from "@components/layouts";
-import { DockerResourceLink, ShowHideButton } from "@components/util";
+import { DockerResourceLink } from "@components/util";
 import { format_size_bytes } from "@lib/formatting";
 import { useRead } from "@lib/hooks";
 import { Badge } from "@ui/badge";
 import { DataTable, SortableHeader } from "@ui/data-table";
-import { HardDrive } from "lucide-react";
-import { Prune } from "../actions";
+import { ReactNode } from "react";
 
 export const Images = ({
   id,
-  show,
-  setShow,
+  titleOther,
 }: {
   id: string;
-  show: boolean;
-  setShow: (show: boolean) => void;
+  titleOther: ReactNode;
 }) => {
   const images =
     useRead("ListDockerImages", { server: id }, { refetchInterval: 10_000 })
       .data ?? [];
 
-  const allInUse = images.every((image) => image.in_use);
-
   return (
-    <div className={show ? "mb-8" : undefined}>
-      <Section
-        title="Images"
-        icon={<HardDrive className="w-4 h-4" />}
-        actions={
-          <div className="flex items-center gap-2">
-            {!allInUse && <Prune server_id={id} type="Images" />}
-            <ShowHideButton show={show} setShow={setShow} />
-          </div>
-        }
-      >
-        {show && (
-          <DataTable
-            tableKey="server-images"
-            data={images}
-            columns={[
-              {
-                accessorKey: "name",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Name" />
-                ),
-                cell: ({ row }) => (
-                  <DockerResourceLink
-                    type="image"
-                    server_id={id}
-                    name={row.original.name}
-                    id={row.original.id}
-                    extra={
-                      !row.original.in_use && (
-                        <Badge variant="destructive">Unused</Badge>
-                      )
-                    }
-                  />
-                ),
-                size: 200,
-              },
-              {
-                accessorKey: "id",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Id" />
-                ),
-              },
-              {
-                accessorKey: "size",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Size" />
-                ),
-                cell: ({ row }) =>
-                  row.original.size
-                    ? format_size_bytes(row.original.size)
-                    : "Unknown",
-              },
-            ]}
-          />
-        )}
-      </Section>
-    </div>
+    <Section titleOther={titleOther}>
+      <DataTable
+        tableKey="server-images"
+        data={images}
+        columns={[
+          {
+            accessorKey: "name",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Name" />
+            ),
+            cell: ({ row }) => (
+              <DockerResourceLink
+                type="image"
+                server_id={id}
+                name={row.original.name}
+                id={row.original.id}
+                extra={
+                  !row.original.in_use && (
+                    <Badge variant="destructive">Unused</Badge>
+                  )
+                }
+              />
+            ),
+            size: 200,
+          },
+          {
+            accessorKey: "id",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Id" />
+            ),
+          },
+          {
+            accessorKey: "size",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Size" />
+            ),
+            cell: ({ row }) =>
+              row.original.size
+                ? format_size_bytes(row.original.size)
+                : "Unknown",
+          },
+        ]}
+      />
+    </Section>
   );
 };

--- a/frontend/src/components/resources/server/info/index.tsx
+++ b/frontend/src/components/resources/server/info/index.tsx
@@ -7,7 +7,7 @@ import { useLocalStorage } from "@lib/hooks";
 import { Images } from "./images";
 import { Containers } from "./containers";
 import { Volumes } from "./volumes";
-import { Button } from "@ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@ui/tabs";
 
 export const ServerInfo = ({
   id,
@@ -17,17 +17,9 @@ export const ServerInfo = ({
   titleOther: ReactNode;
 }) => {
   const state = useServer(id)?.info.state ?? Types.ServerState.NotOk;
-  const [show, setShow] = useLocalStorage<{
-    containers: boolean;
-    networks: boolean;
-    images: boolean;
-    volumes: boolean;
-  }>("server-info-show-config", {
-    containers: true,
-    networks: true,
-    images: true,
-    volumes: true,
-  });
+  const [show2, setShow2] = useLocalStorage<
+    "Containers" | "Networks" | "Volumes" | "Images"
+  >("server-info-show-config-v2", "Containers");
 
   if ([Types.ServerState.NotOk, Types.ServerState.Disabled].includes(state)) {
     return (
@@ -39,50 +31,39 @@ export const ServerInfo = ({
     );
   }
 
-  const anyOpen = !Object.values(show).every((val) => !val);
+  const tabsList = (
+    <TabsList className="justify-start w-fit">
+      <TabsTrigger value="Containers" className="w-[110px]">
+        Containers
+      </TabsTrigger>
+      <TabsTrigger value="Networks" className="w-[110px]">
+        Networks
+      </TabsTrigger>
+      <TabsTrigger value="Volumes" className="w-[110px]">
+        Volumes
+      </TabsTrigger>
+      <TabsTrigger value="Images" className="w-[110px]">
+        Images
+      </TabsTrigger>
+    </TabsList>
+  );
 
   return (
-    <Section
-      titleOther={titleOther}
-      actions={
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() =>
-            setShow({
-              containers: !anyOpen,
-              networks: !anyOpen,
-              images: !anyOpen,
-              volumes: !anyOpen,
-            })
-          }
-        >
-          {anyOpen ? "Hide All" : "Show All"}
-        </Button>
-      }
-    >
-      <div className="flex flex-col gap-4">
-        <Containers
-          id={id}
-          show={show.containers}
-          setShow={(containers) => setShow({ ...show, containers })}
-        />
-        <Networks
-          id={id}
-          show={show.networks}
-          setShow={(networks) => setShow({ ...show, networks })}
-        />
-        <Volumes
-          id={id}
-          show={show.volumes}
-          setShow={(volumes) => setShow({ ...show, volumes })}
-        />
-        <Images
-          id={id}
-          show={show.images}
-          setShow={(images) => setShow({ ...show, images })}
-        />
-      </div>
+    <Section titleOther={titleOther}>
+      <Tabs value={show2} onValueChange={setShow2 as any}>
+        <TabsContent value="Containers">
+          <Containers id={id} titleOther={tabsList} />
+        </TabsContent>
+        <TabsContent value="Networks">
+          <Networks id={id} titleOther={tabsList} />
+        </TabsContent>
+        <TabsContent value="Volumes">
+          <Volumes id={id} titleOther={tabsList} />
+        </TabsContent>
+        <TabsContent value="Images">
+          <Images id={id} titleOther={tabsList} />
+        </TabsContent>
+      </Tabs>
     </Section>
   );
 };

--- a/frontend/src/components/resources/server/info/networks.tsx
+++ b/frontend/src/components/resources/server/info/networks.tsx
@@ -1,105 +1,89 @@
 import { Section } from "@components/layouts";
-import { DockerResourceLink, ShowHideButton } from "@components/util";
+import { DockerResourceLink } from "@components/util";
 import { useRead } from "@lib/hooks";
 import { Badge } from "@ui/badge";
 import { DataTable, SortableHeader } from "@ui/data-table";
-import { Network } from "lucide-react";
-import { Prune } from "../actions";
+import { ReactNode } from "react";
 
 export const Networks = ({
   id,
-  show,
-  setShow,
+  titleOther,
 }: {
   id: string;
-  show: boolean;
-  setShow: (show: boolean) => void;
+  titleOther: ReactNode;
 }) => {
   const networks =
     useRead("ListDockerNetworks", { server: id }, { refetchInterval: 10_000 })
       .data ?? [];
 
-  const allInUse = networks.every((network) =>
-    // this ignores networks that come in with no name, but they should all come in with name
-    !network.name
-      ? true
-      : ["none", "host", "bridge"].includes(network.name)
-      ? true
-      : network.in_use
-  );
+  // const allInUse = networks.every((network) =>
+  //   // this ignores networks that come in with no name, but they should all come in with name
+  //   !network.name
+  //     ? true
+  //     : ["none", "host", "bridge"].includes(network.name)
+  //       ? true
+  //       : network.in_use
+  // );
 
   return (
-    <div className={show ? "mb-8" : undefined}>
-      <Section
-        title="Networks"
-        icon={<Network className="w-4 h-4" />}
-        actions={
-          <div className="flex items-center gap-2">
-            {!allInUse && <Prune server_id={id} type="Networks" />}
-            <ShowHideButton show={show} setShow={setShow} />
-          </div>
-        }
-      >
-        {show && (
-          <DataTable
-            tableKey="server-networks"
-            data={networks}
-            columns={[
-              {
-                accessorKey: "name",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Name" />
-                ),
-                cell: ({ row }) => (
-                  <div className="flex items-center gap-2">
-                    <DockerResourceLink
-                      type="network"
-                      server_id={id}
-                      name={row.original.name}
-                      extra={
-                        ["none", "host", "bridge"].includes(
-                          row.original.name ?? ""
-                        ) ? (
-                          <Badge variant="outline">System</Badge>
-                        ) : (
-                          !row.original.in_use && (
-                            <Badge variant="destructive">Unused</Badge>
-                          )
-                        )
-                      }
-                    />
-                  </div>
-                ),
-                size: 300,
-              },
-              {
-                accessorKey: "driver",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Driver" />
-                ),
-              },
-              {
-                accessorKey: "scope",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Scope" />
-                ),
-              },
-              {
-                accessorKey: "attachable",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Attachable" />
-                ),
-              },
-              {
-                accessorKey: "ipam_driver",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="IPAM Driver" />
-                ),
-              },
-            ]}
-          />
-        )}
-      </Section>
-    </div>
+    <Section titleOther={titleOther}>
+      <DataTable
+        tableKey="server-networks"
+        data={networks}
+        columns={[
+          {
+            accessorKey: "name",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Name" />
+            ),
+            cell: ({ row }) => (
+              <div className="flex items-center gap-2">
+                <DockerResourceLink
+                  type="network"
+                  server_id={id}
+                  name={row.original.name}
+                  extra={
+                    ["none", "host", "bridge"].includes(
+                      row.original.name ?? ""
+                    ) ? (
+                      <Badge variant="outline">System</Badge>
+                    ) : (
+                      !row.original.in_use && (
+                        <Badge variant="destructive">Unused</Badge>
+                      )
+                    )
+                  }
+                />
+              </div>
+            ),
+            size: 300,
+          },
+          {
+            accessorKey: "driver",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Driver" />
+            ),
+          },
+          {
+            accessorKey: "scope",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Scope" />
+            ),
+          },
+          {
+            accessorKey: "attachable",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Attachable" />
+            ),
+          },
+          {
+            accessorKey: "ipam_driver",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="IPAM Driver" />
+            ),
+          },
+        ]}
+      />
+    </Section>
   );
 };

--- a/frontend/src/components/resources/server/info/networks.tsx
+++ b/frontend/src/components/resources/server/info/networks.tsx
@@ -4,6 +4,7 @@ import { useRead } from "@lib/hooks";
 import { Badge } from "@ui/badge";
 import { DataTable, SortableHeader } from "@ui/data-table";
 import { ReactNode } from "react";
+import { Prune } from "../actions";
 
 export const Networks = ({
   id,
@@ -16,17 +17,20 @@ export const Networks = ({
     useRead("ListDockerNetworks", { server: id }, { refetchInterval: 10_000 })
       .data ?? [];
 
-  // const allInUse = networks.every((network) =>
-  //   // this ignores networks that come in with no name, but they should all come in with name
-  //   !network.name
-  //     ? true
-  //     : ["none", "host", "bridge"].includes(network.name)
-  //       ? true
-  //       : network.in_use
-  // );
+  const allInUse = networks.every((network) =>
+    // this ignores networks that come in with no name, but they should all come in with name
+    !network.name
+      ? true
+      : ["none", "host", "bridge"].includes(network.name)
+        ? true
+        : network.in_use
+  );
 
   return (
-    <Section titleOther={titleOther}>
+    <Section
+      titleOther={titleOther}
+      actions={!allInUse && <Prune server_id={id} type="Networks" />}
+    >
       <DataTable
         tableKey="server-networks"
         data={networks}

--- a/frontend/src/components/resources/server/info/volumes.tsx
+++ b/frontend/src/components/resources/server/info/volumes.tsx
@@ -4,6 +4,7 @@ import { useRead } from "@lib/hooks";
 import { Badge } from "@ui/badge";
 import { DataTable, SortableHeader } from "@ui/data-table";
 import { ReactNode } from "react";
+import { Prune } from "../actions";
 
 export const Volumes = ({
   id,
@@ -16,8 +17,13 @@ export const Volumes = ({
     useRead("ListDockerVolumes", { server: id }, { refetchInterval: 10_000 })
       .data ?? [];
 
+  const allInUse = volumes.every((volume) => volume.in_use);
+
   return (
-    <Section titleOther={titleOther}>
+    <Section
+      titleOther={titleOther}
+      actions={!allInUse && <Prune server_id={id} type="Volumes" />}
+    >
       <DataTable
         tableKey="server-volumes"
         data={volumes}

--- a/frontend/src/components/resources/server/info/volumes.tsx
+++ b/frontend/src/components/resources/server/info/volumes.tsx
@@ -1,78 +1,60 @@
 import { Section } from "@components/layouts";
-import { DockerResourceLink, ShowHideButton } from "@components/util";
+import { DockerResourceLink } from "@components/util";
 import { useRead } from "@lib/hooks";
 import { Badge } from "@ui/badge";
 import { DataTable, SortableHeader } from "@ui/data-table";
-import { Database } from "lucide-react";
-import { Prune } from "../actions";
+import { ReactNode } from "react";
 
 export const Volumes = ({
   id,
-  show,
-  setShow,
+  titleOther,
 }: {
   id: string;
-  show: boolean;
-  setShow: (show: boolean) => void;
+  titleOther: ReactNode;
 }) => {
   const volumes =
     useRead("ListDockerVolumes", { server: id }, { refetchInterval: 10_000 })
       .data ?? [];
 
-  const allInUse = volumes.every((volume) => volume.in_use);
-
   return (
-    <div className={show ? "mb-8" : undefined}>
-      <Section
-        title="Volumes"
-        icon={<Database className="w-4 h-4" />}
-        actions={
-          <div className="flex items-center gap-2">
-            {!allInUse && <Prune server_id={id} type="Volumes" />}
-            <ShowHideButton show={show} setShow={setShow} />
-          </div>
-        }
-      >
-        {show && (
-          <DataTable
-            tableKey="server-volumes"
-            data={volumes}
-            columns={[
-              {
-                accessorKey: "name",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Name" />
-                ),
-                cell: ({ row }) => (
-                  <DockerResourceLink
-                    type="volume"
-                    server_id={id}
-                    name={row.original.name}
-                    extra={
-                      !row.original.in_use && (
-                        <Badge variant="destructive">Unused</Badge>
-                      )
-                    }
-                  />
-                ),
-                size: 200,
-              },
-              {
-                accessorKey: "driver",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Driver" />
-                ),
-              },
-              {
-                accessorKey: "scope",
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="Scope" />
-                ),
-              },
-            ]}
-          />
-        )}
-      </Section>
-    </div>
+    <Section titleOther={titleOther}>
+      <DataTable
+        tableKey="server-volumes"
+        data={volumes}
+        columns={[
+          {
+            accessorKey: "name",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Name" />
+            ),
+            cell: ({ row }) => (
+              <DockerResourceLink
+                type="volume"
+                server_id={id}
+                name={row.original.name}
+                extra={
+                  !row.original.in_use && (
+                    <Badge variant="destructive">Unused</Badge>
+                  )
+                }
+              />
+            ),
+            size: 200,
+          },
+          {
+            accessorKey: "driver",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Driver" />
+            ),
+          },
+          {
+            accessorKey: "scope",
+            header: ({ column }) => (
+              <SortableHeader column={column} title="Scope" />
+            ),
+          },
+        ]}
+      />
+    </Section>
   );
 };

--- a/frontend/src/components/resources/stack/services.tsx
+++ b/frontend/src/components/resources/stack/services.tsx
@@ -69,7 +69,22 @@ export const StackServices = ({
                   </Link>
                 );
               },
-              // size: 200,
+            },
+            {
+              accessorKey: "container.state",
+              size: 160,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="State" />
+              ),
+              cell: ({ row }) => {
+                const state = row.original.container?.state;
+                return (
+                  <StatusBadge
+                    text={state}
+                    intent={container_state_intention(state)}
+                  />
+                );
+              },
             },
             {
               accessorKey: "container.image",
@@ -111,24 +126,6 @@ export const StackServices = ({
                     ))}
                 </div>
               ),
-              // size: 200,
-            },
-            {
-              accessorKey: "container.state",
-              size: 160,
-              header: ({ column }) => (
-                <SortableHeader column={column} title="State" />
-              ),
-              cell: ({ row }) => {
-                const state = row.original.container?.state;
-                return (
-                  <StatusBadge
-                    text={state}
-                    intent={container_state_intention(state)}
-                  />
-                );
-              },
-              // size: 120,
             },
           ]}
         />

--- a/frontend/src/components/resources/stack/services.tsx
+++ b/frontend/src/components/resources/stack/services.tsx
@@ -8,11 +8,11 @@ import { cn } from "@lib/utils";
 import { DataTable, SortableHeader } from "@ui/data-table";
 import { useStack } from ".";
 import { Types } from "komodo_client";
-import { ReactNode } from "react";
+import { Fragment, ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { Button } from "@ui/button";
 import { Layers2 } from "lucide-react";
-import { StatusBadge } from "@components/util";
+import { DockerResourceLink, StatusBadge } from "@components/util";
 
 export const StackServices = ({
   id,
@@ -21,7 +21,9 @@ export const StackServices = ({
   id: string;
   titleOther: ReactNode;
 }) => {
-  const state = useStack(id)?.info.state ?? Types.StackState.Unknown;
+  const info = useStack(id)?.info;
+  const server_id = info?.server_id;
+  const state = info?.state ?? Types.StackState.Unknown;
   const services = useRead(
     "ListStackServices",
     { stack: id },
@@ -43,6 +45,7 @@ export const StackServices = ({
           columns={[
             {
               accessorKey: "service",
+              size: 200,
               header: ({ column }) => (
                 <SortableHeader column={column} title="Service" />
               ),
@@ -70,14 +73,49 @@ export const StackServices = ({
             },
             {
               accessorKey: "container.image",
+              size: 300,
               header: ({ column }) => (
                 <SortableHeader column={column} title="Image" />
               ),
-              cell: ({ row }) => <>{row.original.container?.image}</>,
+              cell: ({ row }) =>
+                server_id && (
+                  <DockerResourceLink
+                    type="image"
+                    server_id={server_id}
+                    name={row.original.container?.image}
+                    id={row.original.container?.image_id}
+                  />
+                ),
+              // size: 200,
+            },
+            {
+              accessorKey: "container.networks.0",
+              size: 300,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="Networks" />
+              ),
+              cell: ({ row }) => (
+                <div className="flex items-center gap-2 flex-wrap">
+                  {server_id &&
+                    row.original.container?.networks.map((network, i) => (
+                      <Fragment key={network}>
+                        <DockerResourceLink
+                          type="network"
+                          server_id={server_id}
+                          name={network}
+                        />
+                        {i !== row.original.container!.networks.length - 1 && (
+                          <div className="text-muted-foreground">|</div>
+                        )}
+                      </Fragment>
+                    ))}
+                </div>
+              ),
               // size: 200,
             },
             {
               accessorKey: "container.state",
+              size: 160,
               header: ({ column }) => (
                 <SortableHeader column={column} title="State" />
               ),

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -18,7 +18,7 @@ import { homeViewAtom } from "@main";
 export const Sidebar = () => {
   const [view, setView] = useAtom(homeViewAtom);
   return (
-    <div className="fixed top-0 pt-24 w-64 border-r hidden lg:block pr-8 pb-8 h-screen overflow-y-auto">
+    <div className="fixed top-0 pt-[84px] w-[200px] border-r hidden lg:block pr-8 pb-8 h-screen overflow-y-auto">
       <div className="flex flex-col gap-1">
         <SidebarLink
           label="Dashboard"

--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -705,12 +705,14 @@ export const DockerContainersSection = ({
   show = true,
   setShow,
   pruneButton,
+  titleOther,
 }: {
   server_id: string;
   containers: Types.ListDockerContainersResponse;
   show?: boolean;
   setShow?: (show: boolean) => void;
   pruneButton?: boolean;
+  titleOther?: ReactNode;
 }) => {
   const allRunning = useRead("ListDockerContainers", {
     server: server_id,
@@ -720,8 +722,9 @@ export const DockerContainersSection = ({
   return (
     <div className={cn(setShow && show && "mb-8")}>
       <Section
-        title="Containers"
-        icon={<Box className="w-4 h-4" />}
+        titleOther={titleOther}
+        title={!titleOther ? "Containers" : undefined}
+        icon={!titleOther ? <Box className="w-4 h-4" /> : undefined}
         actions={
           <div className="flex items-center gap-2">
             {pruneButton && !allRunning && (

--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -891,7 +891,7 @@ export const TextUpdateMenuSimple = ({
             triggerClassName
           )}
         >
-          {value || placeholder}
+          {value.split("\n")[0] || placeholder}
         </div>
       </DialogTrigger>
       <DialogContent className="min-w-[50vw]">

--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -755,6 +755,22 @@ export const DockerContainersSection = ({
                 ),
               },
               {
+                accessorKey: "state",
+                size: 160,
+                header: ({ column }) => (
+                  <SortableHeader column={column} title="State" />
+                ),
+                cell: ({ row }) => {
+                  const state = row.original?.state;
+                  return (
+                    <StatusBadge
+                      text={state}
+                      intent={container_state_intention(state)}
+                    />
+                  );
+                },
+              },
+              {
                 accessorKey: "image",
                 size: 300,
                 header: ({ column }) => (
@@ -791,22 +807,6 @@ export const DockerContainersSection = ({
                     ))}
                   </div>
                 ),
-              },
-              {
-                accessorKey: "state",
-                size: 160,
-                header: ({ column }) => (
-                  <SortableHeader column={column} title="State" />
-                ),
-                cell: ({ row }) => {
-                  const state = row.original?.state;
-                  return (
-                    <StatusBadge
-                      text={state}
-                      intent={container_state_intention(state)}
-                    />
-                  );
-                },
               },
             ]}
           />

--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -1,5 +1,6 @@
 import {
   FocusEventHandler,
+  Fragment,
   MouseEventHandler,
   ReactNode,
   forwardRef,
@@ -677,7 +678,7 @@ export const DockerResourceLink = ({
         <Icon server_id={server_id} name={type === "image" ? id : name} />
         <div
           title={name}
-          className="max-w-[200px] lg:max-w-[300px] overflow-hidden overflow-ellipsis"
+          className="max-w-[200px] lg:max-w-[250px] overflow-hidden overflow-ellipsis"
         >
           {name}
         </div>
@@ -741,6 +742,7 @@ export const DockerContainersSection = ({
             columns={[
               {
                 accessorKey: "name",
+                size: 260,
                 header: ({ column }) => (
                   <SortableHeader column={column} title="Name" />
                 ),
@@ -751,10 +753,10 @@ export const DockerContainersSection = ({
                     name={row.original.name}
                   />
                 ),
-                size: 200,
               },
               {
                 accessorKey: "image",
+                size: 300,
                 header: ({ column }) => (
                   <SortableHeader column={column} title="Image" />
                 ),
@@ -768,20 +770,31 @@ export const DockerContainersSection = ({
                 ),
               },
               {
-                accessorKey: "network_mode",
+                accessorKey: "networks.0",
+                size: 300,
                 header: ({ column }) => (
-                  <SortableHeader column={column} title="Network" />
+                  <SortableHeader column={column} title="Networks" />
                 ),
                 cell: ({ row }) => (
-                  <DockerResourceLink
-                    type="network"
-                    server_id={server_id}
-                    name={row.original.network_mode}
-                  />
+                  <div className="flex items-center gap-x-2 flex-wrap">
+                    {row.original.networks.map((network, i) => (
+                      <Fragment key={network}>
+                        <DockerResourceLink
+                          type="network"
+                          server_id={server_id}
+                          name={network}
+                        />
+                        {i !== row.original.networks.length - 1 && (
+                          <div className="text-muted-foreground">|</div>
+                        )}
+                      </Fragment>
+                    ))}
+                  </div>
                 ),
               },
               {
                 accessorKey: "state",
+                size: 160,
                 header: ({ column }) => (
                   <SortableHeader column={column} title="State" />
                 ),

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -259,7 +259,7 @@ export const useAllResources = (): ResourceMap => {
 // Returns true if Komodo has no resources.
 export const useNoResources = () => {
   const resources = useAllResources();
-  for (const target in RESOURCE_TARGETS) {
+  for (const target of RESOURCE_TARGETS) {
     if (resources[target] && resources[target].length) {
       return false;
     }

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -19,6 +19,7 @@ import { useToast } from "@ui/use-toast";
 import { atom, useAtom } from "jotai";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { RESOURCE_TARGETS } from "./utils";
 
 // ============== RESOLVER ==============
 
@@ -235,6 +236,68 @@ export const useResourceParamType = () => {
   return (type[0].toUpperCase() + type.slice(1, -1)) as UsableResource;
 };
 
+type ResourceMap = {
+  [Resource in UsableResource]: Types.ResourceListItem<unknown>[] | undefined;
+};
+
+export const useAllResources = (): ResourceMap => {
+  return {
+    Server: useRead("ListServers", {}).data,
+    Stack: useRead("ListStacks", {}).data,
+    Deployment: useRead("ListDeployments", {}).data,
+    Build: useRead("ListBuilds", {}).data,
+    Repo: useRead("ListRepos", {}).data,
+    Procedure: useRead("ListProcedures", {}).data,
+    Action: useRead("ListActions", {}).data,
+    Builder: useRead("ListBuilders", {}).data,
+    Alerter: useRead("ListAlerters", {}).data,
+    ServerTemplate: useRead("ListServerTemplates", {}).data,
+    ResourceSync: useRead("ListResourceSyncs", {}).data,
+  };
+};
+
+// Returns true if Komodo has no resources.
+export const useNoResources = () => {
+  const resources = useAllResources();
+  for (const target in RESOURCE_TARGETS) {
+    if (resources[target] && resources[target].length) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/** returns function that takes a resource target and checks if it exists */
+export const useCheckResourceExists = () => {
+  const resources = useAllResources();
+  return (target: Types.ResourceTarget) => {
+    return (
+      resources[target.type as UsableResource]?.some(
+        (resource) => resource.id === target.id
+      ) || false
+    );
+  };
+};
+
+export const useFilterResources = <Info>(
+  resources?: Types.ResourceListItem<Info>[],
+  search?: string
+) => {
+  const tags = useTagsFilter();
+  const searchSplit = search?.toLowerCase()?.split(" ") || [];
+  return (
+    resources?.filter(
+      (resource) =>
+        tags.every((tag: string) => resource.tags.includes(tag)) &&
+        (searchSplit.length > 0
+          ? searchSplit.every((search) =>
+              resource.name.toLowerCase().includes(search)
+            )
+          : true)
+    ) ?? []
+  );
+};
+
 export const usePushRecentlyViewed = ({ type, id }: Types.ResourceTarget) => {
   const userInvalidate = useUserInvalidate();
 
@@ -283,60 +346,6 @@ export const tagsAtom = atomWithStorage<string[]>("tags-v0", []);
 export const useTagsFilter = () => {
   const [tags] = useAtom<string[]>(tagsAtom);
   return tags;
-};
-
-/** returns function that takes a resource target and checks if it exists */
-export const useCheckResourceExists = () => {
-  const servers = useRead("ListServers", {}).data;
-  const deployments = useRead("ListDeployments", {}).data;
-  const builds = useRead("ListBuilds", {}).data;
-  const repos = useRead("ListRepos", {}).data;
-  const procedures = useRead("ListProcedures", {}).data;
-  const builders = useRead("ListBuilders", {}).data;
-  const alerters = useRead("ListAlerters", {}).data;
-  return (target: Types.ResourceTarget) => {
-    switch (target.type) {
-      case "Server":
-        return servers?.some((resource) => resource.id === target.id) || false;
-      case "Deployment":
-        return (
-          deployments?.some((resource) => resource.id === target.id) || false
-        );
-      case "Build":
-        return builds?.some((resource) => resource.id === target.id) || false;
-      case "Repo":
-        return repos?.some((resource) => resource.id === target.id) || false;
-      case "Procedure":
-        return (
-          procedures?.some((resource) => resource.id === target.id) || false
-        );
-      case "Builder":
-        return builders?.some((resource) => resource.id === target.id) || false;
-      case "Alerter":
-        return alerters?.some((resource) => resource.id === target.id) || false;
-      default:
-        return false;
-    }
-  };
-};
-
-export const useFilterResources = <Info>(
-  resources?: Types.ResourceListItem<Info>[],
-  search?: string
-) => {
-  const tags = useTagsFilter();
-  const searchSplit = search?.toLowerCase()?.split(" ") || [];
-  return (
-    resources?.filter(
-      (resource) =>
-        tags.every((tag: string) => resource.tags.includes(tag)) &&
-        (searchSplit.length > 0
-          ? searchSplit.every((search) =>
-              resource.name.toLowerCase().includes(search)
-            )
-          : true)
-    ) ?? []
-  );
 };
 
 export type LocalStorageSetter<T> = (state: T) => T;
@@ -407,44 +416,6 @@ export const useCtrlKeyListener = (listenKey: string, onPress: () => void) => {
     document.addEventListener("keydown", keydown);
     return () => document.removeEventListener("keydown", keydown);
   });
-};
-
-// Returns true if Komodo has no resources.
-export const useNoResources = () => {
-  const servers =
-    useRead("ListServers", {}, { refetchInterval: 5000 }).data?.length ?? 0;
-  const deployments =
-    useRead("ListDeployments", {}, { refetchInterval: 5000 }).data?.length ?? 0;
-  const stacks =
-    useRead("ListStacks", {}, { refetchInterval: 5000 }).data?.length ?? 0;
-  const builds =
-    useRead("ListBuilds", {}, { refetchInterval: 5000 }).data?.length ?? 0;
-  const repos =
-    useRead("ListRepos", {}, { refetchInterval: 5000 }).data?.length ?? 0;
-  const procedures =
-    useRead("ListProcedures", {}, { refetchInterval: 5000 }).data?.length ?? 0;
-  const builders =
-    useRead("ListBuilders", {}, { refetchInterval: 5000 }).data?.length ?? 0;
-  const alerters =
-    useRead("ListAlerters", {}, { refetchInterval: 5000 }).data?.length ?? 0;
-  const templates =
-    useRead("ListServerTemplates", {}, { refetchInterval: 5000 }).data
-      ?.length ?? 0;
-  const syncs =
-    useRead("ListResourceSyncs", {}, { refetchInterval: 5000 }).data?.length ??
-    0;
-  return (
-    servers === 0 &&
-    deployments === 0 &&
-    stacks === 0 &&
-    builds === 0 &&
-    repos === 0 &&
-    procedures === 0 &&
-    builders === 0 &&
-    alerters === 0 &&
-    templates === 0 &&
-    syncs === 0
-  );
 };
 
 export type WebhookIntegration = "Github" | "Gitlab";

--- a/frontend/src/pages/containers.tsx
+++ b/frontend/src/pages/containers.tsx
@@ -6,7 +6,7 @@ import { useRead } from "@lib/hooks";
 import { DataTable, SortableHeader } from "@ui/data-table";
 import { Input } from "@ui/input";
 import { Box, Search } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { Fragment, useCallback, useMemo, useState } from "react";
 
 export const ContainersPage = () => {
   const [search, setSearch] = useState("");
@@ -54,6 +54,7 @@ export const ContainersPage = () => {
           columns={[
             {
               accessorKey: "name",
+              size: 260,
               header: ({ column }) => (
                 <SortableHeader column={column} title="Name" />
               ),
@@ -64,10 +65,26 @@ export const ContainersPage = () => {
                   name={row.original.name}
                 />
               ),
-              size: 200,
+            },
+            {
+              accessorKey: "state",
+              size: 160,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="State" />
+              ),
+              cell: ({ row }) => {
+                const state = row.original?.state;
+                return (
+                  <StatusBadge
+                    text={state}
+                    intent={container_state_intention(state)}
+                  />
+                );
+              },
             },
             {
               accessorKey: "server_id",
+              size: 200,
               sortingFn: (a, b) => {
                 const sa = serverName(a.original.server_id!);
                 const sb = serverName(b.original.server_id!);
@@ -89,6 +106,7 @@ export const ContainersPage = () => {
             },
             {
               accessorKey: "image",
+              size: 300,
               header: ({ column }) => (
                 <SortableHeader column={column} title="Image" />
               ),
@@ -102,33 +120,51 @@ export const ContainersPage = () => {
               ),
             },
             {
-              accessorKey: "network_mode",
+              accessorKey: "networks.0",
+              size: 300,
               header: ({ column }) => (
-                <SortableHeader column={column} title="Network" />
+                <SortableHeader column={column} title="Networks" />
               ),
               cell: ({ row }) => (
-                <DockerResourceLink
-                  type="network"
-                  server_id={row.original.server_id!}
-                  name={row.original.network_mode}
-                />
+                <div className="flex items-center gap-x-2 flex-wrap">
+                  {row.original.networks.map((network, i) => (
+                    <Fragment key={network}>
+                      <DockerResourceLink
+                        type="network"
+                        server_id={row.original.server_id!}
+                        name={network}
+                      />
+                      {i !== row.original.networks.length - 1 && (
+                        <div className="text-muted-foreground">|</div>
+                      )}
+                    </Fragment>
+                  ))}
+                </div>
               ),
             },
-            {
-              accessorKey: "state",
-              header: ({ column }) => (
-                <SortableHeader column={column} title="State" />
-              ),
-              cell: ({ row }) => {
-                const state = row.original?.state;
-                return (
-                  <StatusBadge
-                    text={state}
-                    intent={container_state_intention(state)}
-                  />
-                );
-              },
-            },
+            // {
+            //   accessorKey: "volumes.0",
+            //   minSize: 300,
+            //   header: ({ column }) => (
+            //     <SortableHeader column={column} title="Volumes" />
+            //   ),
+            //   cell: ({ row }) => (
+            //     <div className="flex items-center gap-x-2 flex-wrap">
+            //       {row.original.volumes.map((volume, i) => (
+            //         <Fragment key={volume}>
+            //           <DockerResourceLink
+            //             type="volume"
+            //             server_id={row.original.server_id!}
+            //             name={volume}
+            //           />
+            //           {i !== row.original.volumes.length - 1 && (
+            //             <div className="text-muted-foreground">|</div>
+            //           )}
+            //         </Fragment>
+            //       ))}
+            //     </div>
+            //   ),
+            // },
           ]}
         />
       </div>

--- a/frontend/src/pages/home/dashboard.tsx
+++ b/frontend/src/pages/home/dashboard.tsx
@@ -25,7 +25,6 @@ import { Link } from "react-router-dom";
 export const Dashboard = () => {
   const noResources = useNoResources();
   const user = useUser().data!;
-
   return (
     <>
       <ActiveResources />

--- a/frontend/src/pages/server-info/container/index.tsx
+++ b/frontend/src/pages/server-info/container/index.tsx
@@ -157,6 +157,10 @@ const ContainerPageInner = ({
           data={[container]}
           columns={[
             {
+              accessorKey: "Id",
+              header: "Id",
+            },
+            {
               accessorKey: "Image",
               header: "Image",
             },

--- a/frontend/src/pages/server-info/image.tsx
+++ b/frontend/src/pages/server-info/image.tsx
@@ -7,6 +7,7 @@ import {
   DockerContainersSection,
   DockerLabelsSection,
   DockerResourcePageName,
+  ShowHideButton,
 } from "@components/util";
 import { fmt_date_with_minutes, format_size_bytes } from "@lib/formatting";
 import { useExecute, useRead, useSetTitle } from "@lib/hooks";
@@ -15,8 +16,17 @@ import { Types } from "komodo_client";
 import { Badge } from "@ui/badge";
 import { Button } from "@ui/button";
 import { DataTable } from "@ui/data-table";
-import { ChevronLeft, HistoryIcon, Info, Loader2, Trash } from "lucide-react";
+import {
+  ChevronLeft,
+  HistoryIcon,
+  Info,
+  Loader2,
+  SearchCode,
+  Trash,
+} from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useState } from "react";
+import { MonacoEditor } from "@components/monaco";
 
 export const ImagePage = () => {
   const { type, id, image } = useParams() as {
@@ -37,6 +47,7 @@ const ImagePageInner = ({
   id: string;
   image: string;
 }) => {
+  const [showInspect, setShowInspect] = useState(false);
   const server = useServer(id);
   useSetTitle(`${server?.name} | image | ${image_name}`);
   const nav = useNavigate();
@@ -212,6 +223,24 @@ const ImagePageInner = ({
       )}
 
       <DockerLabelsSection labels={image?.Config?.Labels} />
+
+      <Section
+        title="Inspect"
+        icon={<SearchCode className="w-4 h-4" />}
+        titleRight={
+          <div className="pl-2">
+            <ShowHideButton show={showInspect} setShow={setShowInspect} />
+          </div>
+        }
+      >
+        {showInspect && (
+          <MonacoEditor
+            value={JSON.stringify(image, null, 2)}
+            language="json"
+            readOnly
+          />
+        )}
+      </Section>
     </div>
   );
 };

--- a/frontend/src/pages/server-info/network.tsx
+++ b/frontend/src/pages/server-info/network.tsx
@@ -8,6 +8,7 @@ import {
   DockerOptions,
   DockerResourceLink,
   DockerResourcePageName,
+  ShowHideButton,
 } from "@components/util";
 import { useExecute, useRead, useSetTitle } from "@lib/hooks";
 import { has_minimum_permissions } from "@lib/utils";
@@ -20,10 +21,13 @@ import {
   ChevronLeft,
   Info,
   Loader2,
+  SearchCode,
   Trash,
   Waypoints,
 } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useState } from "react";
+import { MonacoEditor } from "@components/monaco";
 
 export const NetworkPage = () => {
   const { type, id, network } = useParams() as {
@@ -44,6 +48,7 @@ const NetworkPageInner = ({
   id: string;
   network: string;
 }) => {
+  const [showInspect, setShowInspect] = useState(false);
   const server = useServer(id);
   useSetTitle(`${server?.name} | network | ${network_name}`);
   const nav = useNavigate();
@@ -277,6 +282,24 @@ const NetworkPageInner = ({
       )}
 
       <DockerLabelsSection labels={network.Labels} />
+
+      <Section
+        title="Inspect"
+        icon={<SearchCode className="w-4 h-4" />}
+        titleRight={
+          <div className="pl-2">
+            <ShowHideButton show={showInspect} setShow={setShowInspect} />
+          </div>
+        }
+      >
+        {showInspect && (
+          <MonacoEditor
+            value={JSON.stringify(network, null, 2)}
+            language="json"
+            readOnly
+          />
+        )}
+      </Section>
     </div>
   );
 };

--- a/frontend/src/pages/server-info/volume.tsx
+++ b/frontend/src/pages/server-info/volume.tsx
@@ -8,6 +8,7 @@ import {
   DockerLabelsSection,
   DockerOptions,
   DockerResourcePageName,
+  ShowHideButton,
 } from "@components/util";
 import { useExecute, useRead, useSetTitle } from "@lib/hooks";
 import { has_minimum_permissions } from "@lib/utils";
@@ -15,8 +16,10 @@ import { Types } from "komodo_client";
 import { Badge } from "@ui/badge";
 import { Button } from "@ui/button";
 import { DataTable } from "@ui/data-table";
-import { ChevronLeft, Info, Loader2, Trash } from "lucide-react";
+import { ChevronLeft, Info, Loader2, SearchCode, Trash } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useState } from "react";
+import { MonacoEditor } from "@components/monaco";
 
 export const VolumePage = () => {
   const { type, id, volume } = useParams() as {
@@ -37,6 +40,7 @@ const VolumePageInner = ({
   id: string;
   volume: string;
 }) => {
+  const [showInspect, setShowInspect] = useState(false);
   const server = useServer(id);
   useSetTitle(`${server?.name} | volume | ${volume_name}`);
   const nav = useNavigate();
@@ -114,7 +118,7 @@ const VolumePageInner = ({
         {/* TITLE */}
         <div className="flex items-center gap-4">
           <div className="mt-1">
-            <DOCKER_LINK_ICONS.container
+            <DOCKER_LINK_ICONS.volume
               server_id={id}
               name={volume_name}
               size={8}
@@ -175,6 +179,24 @@ const VolumePageInner = ({
       </Section>
 
       <DockerLabelsSection labels={volume.Labels} />
+
+      <Section
+        title="Inspect"
+        icon={<SearchCode className="w-4 h-4" />}
+        titleRight={
+          <div className="pl-2">
+            <ShowHideButton show={showInspect} setShow={setShowInspect} />
+          </div>
+        }
+      >
+        {showInspect && (
+          <MonacoEditor
+            value={JSON.stringify(volume, null, 2)}
+            language="json"
+            readOnly
+          />
+        )}
+      </Section>
     </div>
   );
 };

--- a/frontend/src/pages/settings/variables.tsx
+++ b/frontend/src/pages/settings/variables.tsx
@@ -1,4 +1,8 @@
-import { ConfirmButton, CopyButton, TextUpdateMenuMonaco } from "@components/util";
+import {
+  ConfirmButton,
+  CopyButton,
+  TextUpdateMenuMonaco,
+} from "@components/util";
 import {
   useInvalidate,
   useRead,
@@ -209,7 +213,7 @@ export const Variables = () => {
 
       {/** SECRETS */}
       {secrets.length ? (
-        <div className="flex items-center gap-2 text-muted-foreground">
+        <div className="flex items-center gap-2 flex-wrap text-muted-foreground">
           <div>Core Secrets:</div>
           {secrets.map((secret) => (
             <Badge variant="secondary">{secret}</Badge>

--- a/frontend/src/pages/stack-service/index.tsx
+++ b/frontend/src/pages/stack-service/index.tsx
@@ -14,16 +14,17 @@ import {
   stroke_color_class_by_intention,
 } from "@lib/color";
 import { useRead, useSetTitle } from "@lib/hooks";
-import { cn, has_minimum_permissions } from "@lib/utils";
+import { cn } from "@lib/utils";
 import { Types } from "komodo_client";
 import { ChevronLeft, Clapperboard, Layers2 } from "lucide-react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { StackServiceLogs } from "./log";
-import { ResourceUpdates } from "@components/updates/resource";
 import { Button } from "@ui/button";
 import { ExportButton } from "@components/export";
-import { AddTags, ResourceTags } from "@components/tags";
-import { DockerResourceLink, StatusBadge } from "@components/util";
+import { DockerResourceLink, ResourcePageHeader } from "@components/util";
+import { useEditPermissions } from "@pages/resource";
+import { ResourceNotifications } from "@pages/resource-notifications";
+import { Fragment } from "react/jsx-runtime";
 
 type IdServiceComponent = React.FC<{ id: string; service?: string }>;
 
@@ -54,15 +55,10 @@ const StackServicePageInner = ({
 }) => {
   const stack = useStack(stack_id);
   useSetTitle(`${stack?.name} | ${service}`);
-  const nav = useNavigate();
-  const perms = useRead("GetPermissionLevel", {
-    target: { type: "Stack", id: stack_id },
-  }).data;
-  const canExecute = has_minimum_permissions(
-    perms,
-    Types.PermissionLevel.Execute
-  );
-  const canWrite = has_minimum_permissions(perms, Types.PermissionLevel.Write);
+  const { canExecute, canWrite } = useEditPermissions({
+    type: "Stack",
+    id: stack_id,
+  });
   const services = useRead("ListStackServices", { stack: stack_id }).data;
   const container = services?.find((s) => s.service === service)?.container;
   const state = container?.state ?? Types.ContainerStateStatusEnum.Empty;
@@ -70,98 +66,119 @@ const StackServicePageInner = ({
   const stroke_color = stroke_color_class_by_intention(intention);
 
   return (
-    <div className="flex flex-col gap-16">
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center justify-between mb-4">
-          <Button
-            className="gap-2"
-            variant="secondary"
-            onClick={() => nav("/stacks/" + stack_id)}
-          >
-            <ChevronLeft className="w-4" /> Back
+    <div>
+      <div className="w-full flex items-center justify-between mb-12">
+        <Link to={"/stacks/" + stack_id}>
+          <Button className="gap-2" variant="secondary">
+            <ChevronLeft className="w-4" />
+            Back
           </Button>
+        </Link>
+        <div className="flex items-center gap-4">
           <ExportButton targets={[{ type: "Stack", id: stack_id }]} />
         </div>
-
-        <div className="flex flex-col gap-4">
-          <div className="flex gap-4 justify-between flex-wrap">
-            <div className="flex items-center gap-4">
-              <div className="mt-1">
-                <Layers2 className={cn("w-8 h-8", stroke_color)} />
+      </div>
+      <div className="flex flex-col xl:flex-row gap-4">
+        {/** HEADER */}
+        <div className="w-full flex flex-col gap-4">
+          <div className="flex flex-col gap-2 border rounded-md">
+            {/* <Components.ResourcePageHeader id={id} /> */}
+            <ResourcePageHeader
+              intent={intention}
+              icon={<Layers2 className={cn("w-8 h-8", stroke_color)} />}
+              name={service}
+              state={state}
+              status={container?.status}
+            />
+            <div className="flex flex-col pb-2 px-4">
+              <div className="flex items-center gap-x-4 gap-y-0 flex-wrap text-muted-foreground">
+                <ResourceLink type="Stack" id={stack_id} />
+                {stack?.info.server_id && (
+                  <>
+                    |
+                    <ResourceLink type="Server" id={stack.info.server_id} />
+                  </>
+                )}
+                {stack?.info.server_id && container?.name && (
+                  <>
+                    |
+                    <DockerResourceLink
+                      type="container"
+                      server_id={stack.info.server_id}
+                      name={container.name}
+                      muted
+                    />
+                  </>
+                )}
+                {stack?.info.server_id && container?.image && (
+                  <>
+                    |
+                    <DockerResourceLink
+                      type="image"
+                      server_id={stack.info.server_id}
+                      name={container.image}
+                      id={container.image_id}
+                      muted
+                    />
+                  </>
+                )}
+                {stack?.info.server_id &&
+                  container?.networks.map((network) => (
+                    <Fragment key={network}>
+                      |
+                      <DockerResourceLink
+                        type="network"
+                        server_id={stack.info.server_id}
+                        name={network}
+                        muted
+                      />
+                    </Fragment>
+                  ))}
+                {stack?.info.server_id &&
+                  container &&
+                  container.volumes.map((volume) => (
+                    <Fragment key={volume}>
+                      |
+                      <DockerResourceLink
+                        type="volume"
+                        server_id={stack.info.server_id}
+                        name={volume}
+                        muted
+                      />
+                    </Fragment>
+                  ))}
               </div>
-              <h1 className="text-3xl">{service}</h1>
-              <div className="flex flex-wrap gap-4 items-center">
-                <StatusBadge text={state} intent={intention} />
-                {container?.status && <div>{container?.status}</div>}
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2">
-              <p className="text-sm text-muted-foreground">Description: </p>
-              <ResourceDescription
-                type="Stack"
-                id={stack_id}
-                disabled={!canWrite}
-              />
             </div>
           </div>
-
-          <div className="flex gap-4 justify-between flex-wrap">
-            <div className="flex flex-wrap gap-4 items-center text-muted-foreground">
-              <ResourceLink type="Stack" id={stack_id} />
-              {stack?.info.server_id && (
-                <>
-                  |
-                  <ResourceLink type="Server" id={stack.info.server_id} />
-                </>
-              )}
-              {stack?.info.server_id && container && container.name && (
-                <>
-                  |
-                  <DockerResourceLink
-                    type="container"
-                    server_id={stack?.info.server_id}
-                    name={container.name}
-                    muted
-                  />
-                </>
-              )}
-            </div>
-
-            <div className="flex items-center gap-2 h-7 lg:justify-self-end">
-              <p className="text-sm text-muted-foreground">Tags:</p>
-              <ResourceTags
-                target={{ id: stack_id, type: "Stack" }}
-                className="text-sm"
-                disabled={!canWrite}
-                click_to_delete
-              />
-              {canWrite && <AddTags target={{ id: stack_id, type: "Stack" }} />}
-            </div>
-          </div>
+          <ResourceDescription
+            type="Stack"
+            id={stack_id}
+            disabled={!canWrite}
+          />
         </div>
+        {/** NOTIFICATIONS */}
+        <ResourceNotifications type="Stack" id={stack_id} />
       </div>
 
-      {/* Actions */}
-      {canExecute && (
-        <Section
-          title="Actions (Service)"
-          icon={<Clapperboard className="w-4 h-4" />}
-        >
-          <div className="flex gap-4 items-center flex-wrap">
-            {Object.entries(Actions).map(([key, Action]) => (
-              <Action key={key} id={stack_id} service={service} />
-            ))}
-          </div>
-        </Section>
-      )}
+      <div className="mt-8 flex flex-col gap-12">
+        {/* Actions */}
+        {canExecute && (
+          <Section
+            title="Actions (Service)"
+            icon={<Clapperboard className="w-4 h-4" />}
+          >
+            <div className="flex gap-4 items-center flex-wrap">
+              {Object.entries(Actions).map(([key, Action]) => (
+                <Action key={key} id={stack_id} service={service} />
+              ))}
+            </div>
+          </Section>
+        )}
 
-      {/* Updates */}
-      <ResourceUpdates type="Stack" id={stack_id} />
-
-      {/* Logs */}
-      <div className="pt-4">
-        <StackServiceLogs id={stack_id} service={service} />
+        {/* Logs */}
+        <div className="pt-4">
+          <StackServiceLogs id={stack_id} service={service} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- **Stack**: 
    - Correctly support replicated services
    - Improve Stack service page
- **Container table**: 
    - Fix incorrect network name (either `container:Id...` or just `Id...`)
    - Show multiple networks in the table
- **Builder**:
    - Add **Url** type - just add Periphery address instead of having to make a `Server`