### PR TITLE
1.16.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "alerter"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "command"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "komodo_client",
  "run_command",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "environment_file"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "thiserror",
 ]
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "formatting"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "serror",
 ]
@@ -1571,7 +1571,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "command",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_cli"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_client"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_core"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "komodo_periphery"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -3090,7 +3090,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "periphery_client"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "komodo_client",
@@ -4865,7 +4865,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update_logger"
-version = "1.16.6"
+version = "1.16.7"
 dependencies = [
  "anyhow",
  "komodo_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.16.6"
+version = "1.16.7"
 edition = "2021"
 authors = ["mbecker20 <becker.maxh@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/bin/core/src/auth/oidc/mod.rs
+++ b/bin/core/src/auth/oidc/mod.rs
@@ -92,13 +92,19 @@ async fn login(
   );
 
   let config = core_config();
-  let redirect = if !config.oidc_redirect.is_empty() {
-    Redirect::to(
-      auth_url
-        .as_str()
-        .replace(&config.oidc_provider, &config.oidc_redirect)
-        .as_str(),
-    )
+  let redirect = if !config.oidc_redirect_host.is_empty() {
+    let auth_url = auth_url.as_str();
+    let (protocol, rest) = auth_url
+      .split_once("://")
+      .context("Invalid URL: Missing protocol (eg 'https://')")?;
+    let host = rest
+      .split_once(['/', '?'])
+      .map(|(host, _)| host)
+      .unwrap_or(rest);
+    Redirect::to(&auth_url.replace(
+      &format!("{protocol}://{host}"),
+      &config.oidc_redirect_host,
+    ))
   } else {
     Redirect::to(auth_url.as_str())
   };

--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -78,7 +78,7 @@ pub fn core_config() -> &'static CoreConfig {
       },
       oidc_enabled: env.komodo_oidc_enabled.unwrap_or(config.oidc_enabled),
       oidc_provider: env.komodo_oidc_provider.unwrap_or(config.oidc_provider),
-      oidc_redirect: env.komodo_oidc_redirect.unwrap_or(config.oidc_redirect),
+      oidc_redirect_host: env.komodo_oidc_redirect_host.unwrap_or(config.oidc_redirect_host),
       oidc_client_id: maybe_read_item_from_file(env.komodo_oidc_client_id_file,env
         .komodo_oidc_client_id)
         .unwrap_or(config.oidc_client_id),

--- a/bin/core/src/helpers/builder.rs
+++ b/bin/core/src/helpers/builder.rs
@@ -31,7 +31,7 @@ use crate::{
 use super::periphery_client;
 
 const BUILDER_POLL_RATE_SECS: u64 = 2;
-const BUILDER_POLL_MAX_TRIES: usize = 30;
+const BUILDER_POLL_MAX_TRIES: usize = 60;
 
 #[instrument(skip_all, fields(builder_id = builder.id, update_id = update.id))]
 pub async fn get_builder_periphery(

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -108,8 +108,8 @@ pub struct Env {
   pub komodo_oidc_enabled: Option<bool>,
   /// Override `oidc_provider`
   pub komodo_oidc_provider: Option<String>,
-  /// Override `oidc_redirect`
-  pub komodo_oidc_redirect: Option<String>,
+  /// Override `oidc_redirect_host`
+  pub komodo_oidc_redirect_host: Option<String>,
   /// Override `oidc_client_id`
   pub komodo_oidc_client_id: Option<String>,
   /// Override `oidc_client_id` from file
@@ -325,18 +325,22 @@ pub struct CoreConfig {
 
   /// Configure OIDC provider address for
   /// communcation directly with Komodo Core.
+  ///
   /// Note. Needs to be reachable from Komodo Core.
-  /// Eg. `https://accounts.example.internal/application/o/komodo`
+  ///
+  /// `https://accounts.example.internal/application/o/komodo`
   #[serde(default)]
   pub oidc_provider: String,
 
-  /// Configure OIDC user redirect address.
-  /// This is the address users are redirected to in their browser,
-  /// and may be different from `oidc_provider`.
-  /// If not provided, the `oidc_provider` will be used.
-  /// Eg. `https://accounts.example.external/application/o/komodo`
+  /// Configure OIDC user redirect host.
+  ///
+  /// This is the host address users are redirected to in their browser,
+  /// and may be different from `oidc_provider` host.
+  /// DO NOT include the `path` part, this must be inferred.
+  /// If not provided, the host will be the same as `oidc_provider`.
+  /// Eg. `https://accounts.example.external`
   #[serde(default)]
-  pub oidc_redirect: String,
+  pub oidc_redirect_host: String,
 
   /// Set OIDC client id
   #[serde(default)]
@@ -580,7 +584,7 @@ impl CoreConfig {
       local_auth: config.local_auth,
       oidc_enabled: config.oidc_enabled,
       oidc_provider: config.oidc_provider,
-      oidc_redirect: config.oidc_redirect,
+      oidc_redirect_host: config.oidc_redirect_host,
       oidc_client_id: empty_or_redacted(&config.oidc_client_id),
       oidc_client_secret: empty_or_redacted(
         &config.oidc_client_secret,

--- a/client/core/ts/package.json
+++ b/client/core/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komodo_client",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "description": "Komodo client package",
   "homepage": "https://komo.do",
   "main": "dist/lib.js",

--- a/compose/compose.env
+++ b/compose/compose.env
@@ -78,8 +78,9 @@ KOMODO_JWT_TTL="1-day"
 KOMODO_OIDC_ENABLED=false
 ## Must reachable from Komodo Core container
 # KOMODO_OIDC_PROVIDER=https://oidc.provider.internal/application/o/komodo
-## Must be reachable by users (optional if it is the same as above).
-# KOMODO_OIDC_REDIRECT=https://oidc.provider.external/application/o/komodo
+## Change the host to one reachable be reachable by users (optional if it is the same as above).
+## DO NOT include the `path` part of the URL.
+# KOMODO_OIDC_REDIRECT_HOST=https://oidc.provider.external
 ## Your client credentials
 # KOMODO_OIDC_CLIENT_ID= # Alt: KOMODO_OIDC_CLIENT_ID_FILE
 # KOMODO_OIDC_CLIENT_SECRET= # Alt: KOMODO_OIDC_CLIENT_SECRET_FILE

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -152,15 +152,18 @@ oidc_enabled = false
 ## Optional, no default.
 oidc_provider = "https://oidc.provider.internal/application/o/komodo"
 
-## Configure OIDC user redirect address.
+## Configure OIDC user redirect host.
 ##
-## This is the address users are redirected to in their browser,
-## and may be different from `oidc_provider` depending on your networking.
+## This is the host address users are redirected to in their browser,
+## and may be different from `oidc_provider` host depending on your networking.
 ## If not provided (or empty string ""), the `oidc_provider` will be used.
 ##
-## Env: KOMODO_OIDC_REDIRECT
+## Note. DO NOT include the `path` part of the URL.
+## Example: `https://oidc.provider.external`
+##
+## Env: KOMODO_OIDC_REDIRECT_HOST
 ## Optional, no default.
-oidc_redirect = ""
+oidc_redirect_host = ""
 
 ## Give the OIDC Client ID.
 ## Env: KOMODO_OIDC_CLIENT_ID or KOMODO_OIDC_CLIENT_ID_FILE


### PR DESCRIPTION
- **OIDC**: If your Komodo Core container reaches your OIDC provider at a different address than your users do from the browser, changes the logic for `KOMODO_OIDC_REDIRECT`. The variable is now renamed to `KOMODO_OIDC_REDIRECT_HOST` and should NOT include the path part of the URL (everything after the slash)
    - Example:
      ```
      # This address must be reachable from Core container
      KOMODO_OIDC_PROVIDER=http://oidc.provider.internal:9000/application/o/komodo/
      # The host address reachable by users in browser
      KOMODO_OIDC_REDIRECT_HOST=https://oidc.provider.external # Don't include any "path" in the URL.
      
      # Will replace `http://oidc.provider.internal:9000` with `https://oidc.provider.external` in user redirect.
      ```
- Double the AWS Builder timeout to allow User Data more time to setup.