### PR TITLE
feature: use the repo path instead of name in GetLatestCommit

### DIFF
--- a/bin/core/src/monitor/mod.rs
+++ b/bin/core/src/monitor/mod.rs
@@ -263,7 +263,7 @@ pub async fn update_cache_for_server(server: &Server) {
   for repo in repos {
     let (latest_hash, latest_message) = periphery
       .request(GetLatestCommit {
-        name: repo.name.clone(),
+        path: repo.config.path.clone(),
       })
       .await
       .map(|r| (r.hash, r.message))

--- a/bin/periphery/src/api/git.rs
+++ b/bin/periphery/src/api/git.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use anyhow::{anyhow, Context};
 use git::GitRes;
 use komodo_client::entities::{update::Log, CloneArgs, LatestCommit};
@@ -16,10 +17,10 @@ impl Resolve<super::Args> for GetLatestCommit {
     self,
     _: &super::Args,
   ) -> serror::Result<LatestCommit> {
-    let repo_path = periphery_config().repo_dir.join(self.name);
+    let repo_path = PathBuf::from(self.path);
     if !repo_path.is_dir() {
       return Err(
-        anyhow!("Repo path is not directory. is it cloned?").into(),
+        anyhow!("Repo path {} is not directory. is it cloned?", repo_path.display().to_string()).into(),
       );
     }
     Ok(git::get_commit_hash_info(&repo_path).await?)

--- a/client/periphery/rs/src/api/git.rs
+++ b/client/periphery/rs/src/api/git.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[response(LatestCommit)]
 #[error(serror::Error)]
 pub struct GetLatestCommit {
-  pub name: String,
+  pub path: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Resolve)]


### PR DESCRIPTION
I had these annoying warning in my logs : 

```
periphery-1  | 2025-01-31T09:19:01.181038Z  WARN periphery::router: request 9cfd7951-de61-4394-8bda-6c37c3b391a7 | type: GetLatestCommit | error: Repo path is not directory. is it cloned?
periphery-1  | 2025-01-31T09:19:16.026513Z  WARN periphery::router: request 3658378e-5e1a-49de-b7d1-234c78d6dc14 | type: GetLatestCommit | error: Repo path is not directory. is it cloned?
```

I did some digging, forked the repo, added the `repo_path` to the error log and i think i found the issue.

The `GetLatestCommit` command takes the repo name as set in the UI, but since we can override the clone path we can end up is a different path than this : 

```
    let repo_path = periphery_config().repo_dir.join(self.name);
```

So the fix, imho, should be to use the repo `path` instead of the name, since even if we don't override the clone path, there is always a value set : 

```
.request(GetLatestCommit {
        clone_path: repo.config.path.clone(),
      })
```

I'm not sure what is the contributions guidelines in terms of testing, but on my end what i did was to build the docker images, pulled it on my servers and saw i didn't get the warnings anymore.

Feedback welcomed 🙏 


PS: i based this PR on the 1.17 branch, but i have a branch ready with the same change for 1.16