### PR TITLE
[PR] Fix for the spamming /auth/GetUser when unexpected logout occured

### DIFF
--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -37,7 +37,7 @@ export const useLoginOptions = () =>
   });
 
 export const useUser = () => {
-  const userInvalidate = useUserInvalidate();
+  const userReset = useUserReset();
   const query = useQuery({
     queryKey: ["GetUser"],
     queryFn: () => komodo_client().auth("GetUser", {}),
@@ -45,7 +45,7 @@ export const useUser = () => {
   });
   useEffect(() => {
     if (query.data && query.error) {
-      userInvalidate();
+      userReset();
     }
   }, [query.data, query.error]);
   return query;
@@ -55,6 +55,13 @@ export const useUserInvalidate = () => {
   const qc = useQueryClient();
   return () => {
     qc.invalidateQueries({ queryKey: ["GetUser"] });
+  };
+};
+
+export const useUserReset = () => {
+  const qc = useQueryClient();
+  return () => {
+    qc.resetQueries({ queryKey: ["GetUser"] });
   };
 };
 


### PR DESCRIPTION
# Description
Environment: 
Komodo core version: 1.18.3
Browser: Chrome / Safari

The case happens when I put the komodo browser idle long enough (e.g. put a sleep on my mac and keep my browser open) , the token timed out. 
I have seen the network and cpu usage goes up. 

After checking the browser console, I found that `/auth/GetUser` are spammed to the Komodo core server.
Here are the reproducible steps:
1. Login Komodo
2.  Deleting `komodo-auth-token` from Local Storage, forcing them to logout, and wait for approx. 10s to redirect back to login page
3. The `/auth/GetUser` requests are getting spammed to the Komodo core server, spiking the CPU and network usage.
![spam](https://github.com/user-attachments/assets/e40a27bd-dd71-4d2e-a0a9-faf92b3448dd)

And after extensive checking, found that the `qc.invalidateQueries` does not return updated `userData` after the invalidation. (Checked the data shows that the `query.data` still have the user data, which the new response on `/auth/GetUsers` is a HTTP 500 error) 

Later found that the `qc.resetQueries` will stop the spam, but since I do no exp on React, I am not sure if it is best practice or not breaking other imports using `useUser`, breaking existing logics etc.



