### PR TITLE
docs(docker-compose): Fix obsolete repo-cache volume declaration

### DIFF
--- a/compose/ferretdb.compose.yaml
+++ b/compose/ferretdb.compose.yaml
@@ -89,5 +89,3 @@ volumes:
   postgres-data:
   # FerretDB
   ferretdb-state:
-  # Core
-  repo-cache:

--- a/compose/mongo.compose.yaml
+++ b/compose/mongo.compose.yaml
@@ -71,5 +71,3 @@ volumes:
   # Mongo
   mongo-data:
   mongo-config:
-  # Core
-  repo-cache:


### PR DESCRIPTION
Hello,

Since 1.19.0, the `/repo-cache` mount from Core compose service has been removed.
The composes files still declare a `repo-cache` volume, now unused.

This PR removes the `repo-cache` volumes declarations.

Thank you