### PR TITLE
Add server name filter to Containers tab

### DIFF
--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -805,3 +805,24 @@ export const useContainerPortsMap = (ports: Types.Port[]) => {
     return map;
   }, [ports]);
 };
+
+/**
+ * A custom React hook that debounces a value, delaying its update until after
+ * a specified period of inactivity. This is useful for performance optimization
+ * in scenarios like search inputs, form validation, or API calls.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/ui/multi-select.tsx
+++ b/frontend/src/ui/multi-select.tsx
@@ -1,0 +1,161 @@
+import * as React from "react";
+import { Check, ChevronsUpDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/ui/badge";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
+import { Skeleton } from "@/ui/skeleton";
+
+interface MultiSelectProps {
+  options?: { label: string; value: string }[];
+  value: string[];
+  onChange: (selected: string[]) => void;
+  placeholder?: string;
+  className?: string;
+  isLoading?: boolean;
+  disabled?: boolean;
+}
+
+function MultiSelect({
+  options,
+  value,
+  onChange,
+  placeholder = "Select items...",
+  className,
+  isLoading = false,
+  disabled = false,
+}: MultiSelectProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleUnselect = (item: string) => {
+    onChange(value.filter((i) => i !== item));
+  };
+
+  const handleSelect = (item: string) => {
+    if (value.includes(item)) {
+      handleUnselect(item);
+    } else {
+      onChange([...value, item]);
+    }
+  };
+
+  return (
+    <div className={cn("w-full", className)}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          className={cn(
+            "flex h-full w-full transition-all items-center justify-between rounded-md border border-input bg-background text-sm",
+            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            "hover:bg-accent hover:text-accent-foreground"
+          )}
+          disabled={disabled}
+          aria-expanded={open}
+        >
+          <div className="flex justify-between flex-1 overflow-hidden">
+            <div
+              className="flex gap-1 flex-1 py-2 px-3 overflow-x-auto"
+              style={{
+                scrollbarWidth: "thin",
+                scrollbarColor: "hsl(var(--border)) transparent",
+              }}
+            >
+              {value.length === 0 ? (
+                <span className="text-muted-foreground truncate">
+                  {placeholder}
+                </span>
+              ) : (
+                value.map((item) => {
+                  const option = options?.find((opt) => opt.value === item);
+                  return (
+                    <Badge key={item} variant="default" className="text-xs">
+                      {option?.label}
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        className="ml-1 hover:bg-destructive transition-all hover:text-destructive-foreground rounded-full p-0.5"
+                        onKeyDown={(e) =>
+                          e.key === "Enter" && handleUnselect(item)
+                        }
+                        onClick={() => handleUnselect(item)}
+                      >
+                        <X className="h-3 w-3" />
+                      </span>
+                    </Badge>
+                  );
+                })
+              )}
+            </div>
+            <hr className="border-l border-border bg-red-300 h-6 mx-0.5 my-auto" />
+            <span
+              role="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen((prev) => !prev);
+              }}
+              tabIndex={0}
+              className={cn(
+                "p-1 mx-1.5 my-auto h-full outline-none",
+                "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                "hover:bg-accent/50 rounded-sm cursor-pointer"
+              )}
+            >
+              <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+            </span>
+          </div>
+        </PopoverTrigger>
+        <PopoverContent className="w-full p-0" align="start">
+          <Command>
+            <CommandInput autoFocus={false} placeholder="Search items..." />
+            <CommandList>
+              <CommandEmpty className="p-0">
+                {isLoading ? (
+                  <div className="p-2">
+                    {Array.from({ length: 6 }).map((_, index) => (
+                      <Skeleton
+                        key={index}
+                        className="h-4 w-full mb-1 last:mb-0"
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-center text-sm py-4 text-muted-foreground">
+                    No items found.
+                  </div>
+                )}
+              </CommandEmpty>
+              <CommandGroup>
+                {options?.map((option) => (
+                  <CommandItem
+                    key={option.value}
+                    value={option.value}
+                    onSelect={() => handleSelect(option.value)}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        value.includes(option.value)
+                          ? "opacity-100"
+                          : "opacity-0"
+                      )}
+                    />
+                    {option.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+export {MultiSelect}

--- a/frontend/src/ui/skeleton.tsx
+++ b/frontend/src/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
Resolves #687

## Description

Added the ability to filter containers by server name in addition to existing container name search.

## Changes

- Enhanced existing search input with debounce function to reduce unnecessary computations
- Added multi-select component for filtering containers by server name
- Integrated skeleton loading component for better loading states
- Added reset button that appears when at least one server is selected

## Screenshots
<img width="1400" height="303" alt="image" src="https://github.com/user-attachments/assets/1fef0a9c-a89f-45a0-a0c1-fc2f125dddc3" />
<img width="1419" height="375" alt="image" src="https://github.com/user-attachments/assets/2a055833-7b1b-4994-ad20-82e411ec2791" />
<img width="1431" height="653" alt="image" src="https://github.com/user-attachments/assets/a191f480-8ed8-4823-bbc0-10fe6f08ceac" />
<img width="427" height="283" alt="image" src="https://github.com/user-attachments/assets/f07a7d82-c4db-45b4-8b44-37f78c3179bb" />