### PR TITLE
Fix navigation link to users page via omnibar

### DIFF
--- a/frontend/src/components/omnibar.tsx
+++ b/frontend/src/components/omnibar.tsx
@@ -1,4 +1,4 @@
-import { useAllResources, useLocalStorage, useRead, useUser } from "@lib/hooks";
+import { useAllResources, useLocalStorage, useRead, useSettingsView, useUser } from "@lib/hooks";
 import { Button } from "@ui/button";
 import {
   CommandDialog,
@@ -126,6 +126,7 @@ const useOmniItems = (
 ): Record<string, OmniItem[]> => {
   const user = useUser().data;
   const resources = useAllResources();
+  const [_, setSettingsView] = useSettingsView();
   return useMemo(() => {
     const searchTerms = search
       .toLowerCase()
@@ -166,7 +167,10 @@ const useOmniItems = (
           type: "Server" as UsableResource,
           label: "Users",
           icon: <User className="w-4 h-4" />,
-          onSelect: () => nav("/users"),
+          onSelect: () => {
+            setSettingsView("Users");
+            nav("/settings");
+          },
           template: false,
         }) as OmniItem,
       ]


### PR DESCRIPTION
As `/users` page was moved into a tab in the `/settings` page via https://github.com/moghtech/komodo/commit/914f4c61975a2fbb0457ceed77d3a252dafe2b37#diff-87aa4da73c5d91a90af8a1b87e8442a664508c2ac5fb45ee932475e91102dfa3, navigating to `/users` using the omnibar doesn't seem to work anymore and shows a blank page. 

This PR refers to the following existing code block to first set the settings view to "Users" tab then navigate the user to the settings page:

https://github.com/moghtech/komodo/blob/a65fd4dca74f262f265e1694e9f146f00d0d70cd/frontend/src/components/config/util.tsx#L1066-L1067

## Before 

https://github.com/user-attachments/assets/c034b656-8fb0-49fd-877b-c8d371eb7933

## After

https://github.com/user-attachments/assets/e6f92594-ac03-4cd1-97c1-48b4d497d506