### PR TITLE
Auth error handling with status codes

### DIFF
--- a/bin/core/src/api/auth.rs
+++ b/bin/core/src/api/auth.rs
@@ -153,9 +153,7 @@ impl Resolve<AuthArgs> for GetUser {
     self,
     AuthArgs { headers }: &AuthArgs,
   ) -> serror::Result<User> {
-    let user_id = get_user_id_from_headers(headers)
-      .await
-      .status_code(StatusCode::UNAUTHORIZED)?;
+    let user_id = get_user_id_from_headers(headers).await.status_code(StatusCode::UNAUTHORIZED)?;
     Ok(get_user(&user_id).await?)
   }
 }


### PR DESCRIPTION
## Problem:
The current error handling in authentication is not optimal, as it always returns HTTP status code 500, regardless of whether no credentials were found in the header, the credentials are incorrect, or the user exists but is disabled. This prevents the client from distinguishing why authentication failed.

I noticed this problem in the browser console when navigating to the login page. Resources are being queried in the background even though we are not logged in. This would certainly be worth its own issue, but I will fix the problem piece by piece in smaller PRs.

## Solution:
Similar to PR #819, I have adjusted the error handling to use different HTTP status codes and provide clearer information to the user about why authentication failed.

401 UNAUTHORIZED