### PR TITLE
feat(core/stack): sync linked repo git settings into Stack config

### DIFF
--- a/bin/core/src/resource/stack.rs
+++ b/bin/core/src/resource/stack.rs
@@ -403,6 +403,9 @@ async fn validate_config(
     .context("Cannot attach Repo to this Stack")?;
     // in case it comes in as name
     config.linked_repo = Some(repo.id);
+    config.git_provider = Some(repo.config.git_provider);
+    config.branch = Some(repo.config.branch);
+    config.git_https = Some(repo.config.git_https);
   }
   Ok(())
 }


### PR DESCRIPTION
Issue: https://github.com/moghtech/komodo/issues/956

- When setting linked_repo in UpdateStack validation, also sync:
  - git_provider
  - branch
  - git_https

Ensures Stack webhook branch checks and git operations align with the linked Repo configuration.