### PR TITLE
Fix undefined user_install variable in main()

### DIFF
--- a/scripts/setup-periphery.py
+++ b/scripts/setup-periphery.py
@@ -232,7 +232,7 @@ def main():
 	write_service_file(args, home_dir, bin_dir, config_dir, service_dir)
 
 	user = ""
-	if user_install:
+	if args.user:
 		user = " --user"
 
 	print("Starting Periphery...")


### PR DESCRIPTION
Fixes a NameError that occurs when starting the Periphery service. The variable `user_install` on line 233 doesn't exist and should be `args.user` to match the rest of the codebase.