### PR TITLE
Upgrade Docker base images from Debian Bullseye to Bookworm

### DIFF
--- a/.devcontainer/dev.compose.yaml
+++ b/.devcontainer/dev.compose.yaml
@@ -1,6 +1,6 @@
 services:
   dev:
-    image: mcr.microsoft.com/devcontainers/rust:1-1-bullseye
+    image: mcr.microsoft.com/devcontainers/rust:1-1-bookworm
     volumes:
       # Mount the root folder that contains .git
       - ../:/workspace:cached

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Komodo",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	//"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+	//"image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
 	"dockerComposeFile": ["dev.compose.yaml"],
 	"workspaceFolder": "/workspace",
   	"service": "dev",

--- a/bin/binaries.Dockerfile
+++ b/bin/binaries.Dockerfile
@@ -1,7 +1,7 @@
 ## Builds the Komodo Core, Periphery, and Util binaries
 ## for a specific architecture.
 
-FROM rust:1.89.0-bullseye AS builder
+FROM rust:1.89.0-bookworm AS builder
 RUN cargo install cargo-strip
 
 WORKDIR /builder

--- a/bin/chef.binaries.Dockerfile
+++ b/bin/chef.binaries.Dockerfile
@@ -3,7 +3,7 @@
 
 ## Uses chef for dependency caching to help speed up back-to-back builds.
 
-FROM lukemathwalker/cargo-chef:latest-rust-1.89.0-bullseye AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.89.0-bookworm AS chef
 WORKDIR /builder
 
 # Plan just the RECIPE to see if things have changed

--- a/bin/cli/aio.Dockerfile
+++ b/bin/cli/aio.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.89.0-bullseye AS builder
+FROM rust:1.89.0-bookworm AS builder
 RUN cargo install cargo-strip
 
 WORKDIR /builder

--- a/bin/cli/multi-arch.Dockerfile
+++ b/bin/cli/multi-arch.Dockerfile
@@ -9,7 +9,7 @@ ARG AARCH64_BINARIES=${BINARIES_IMAGE}-aarch64
 FROM ${X86_64_BINARIES} AS x86_64
 FROM ${AARCH64_BINARIES} AS aarch64
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 

--- a/bin/core/aio.Dockerfile
+++ b/bin/core/aio.Dockerfile
@@ -1,7 +1,7 @@
 ## All in one, multi stage compile + runtime Docker build for your architecture.
 
 # Build Core
-FROM rust:1.89.0-bullseye AS core-builder
+FROM rust:1.89.0-bookworm AS core-builder
 RUN cargo install cargo-strip
 
 WORKDIR /builder
@@ -26,7 +26,7 @@ RUN cd client && yarn && yarn build && yarn link
 RUN cd frontend && yarn link komodo_client && yarn && yarn build
 
 # Final Image
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY ./bin/core/starship.toml /starship.toml
 COPY ./bin/core/debian-deps.sh .

--- a/bin/core/multi-arch.Dockerfile
+++ b/bin/core/multi-arch.Dockerfile
@@ -13,7 +13,7 @@ FROM ${AARCH64_BINARIES} AS aarch64
 FROM ${FRONTEND_IMAGE} AS frontend
 
 # Final Image
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY ./bin/core/starship.toml /starship.toml
 COPY ./bin/core/debian-deps.sh .

--- a/bin/core/single-arch.Dockerfile
+++ b/bin/core/single-arch.Dockerfile
@@ -14,7 +14,7 @@ COPY ./client/core/ts ./client
 RUN cd client && yarn && yarn build && yarn link
 RUN cd frontend && yarn link komodo_client && yarn && yarn build
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY ./bin/core/starship.toml /starship.toml
 COPY ./bin/core/debian-deps.sh .

--- a/bin/periphery/aio.Dockerfile
+++ b/bin/periphery/aio.Dockerfile
@@ -1,6 +1,6 @@
 ## All in one, multi stage compile + runtime Docker build for your architecture.
 
-FROM rust:1.89.0-bullseye AS builder
+FROM rust:1.89.0-bookworm AS builder
 RUN cargo install cargo-strip
 
 WORKDIR /builder
@@ -14,7 +14,7 @@ COPY ./bin/periphery ./bin/periphery
 RUN cargo build -p komodo_periphery --release && cargo strip
 
 # Final Image
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY ./bin/periphery/starship.toml /starship.toml
 COPY ./bin/periphery/debian-deps.sh .

--- a/bin/periphery/multi-arch.Dockerfile
+++ b/bin/periphery/multi-arch.Dockerfile
@@ -10,7 +10,7 @@ ARG AARCH64_BINARIES=${BINARIES_IMAGE}-aarch64
 FROM ${X86_64_BINARIES} AS x86_64
 FROM ${AARCH64_BINARIES} AS aarch64
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY ./bin/periphery/starship.toml /starship.toml
 COPY ./bin/periphery/debian-deps.sh .

--- a/bin/periphery/single-arch.Dockerfile
+++ b/bin/periphery/single-arch.Dockerfile
@@ -6,7 +6,7 @@ ARG BINARIES_IMAGE=ghcr.io/moghtech/komodo-binaries:latest
 # This is required to work with COPY --from
 FROM ${BINARIES_IMAGE} AS binaries
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY ./bin/periphery/starship.toml /starship.toml
 COPY ./bin/periphery/debian-deps.sh .


### PR DESCRIPTION
# Security: Upgrade Docker base images from Debian Bullseye to Bookworm

## Problem
I stumbled upon critical CVEs in the Debian Bullseye base images currently used across all Dockerfiles.

## Solution
Updated all Docker base images from Debian Bullseye to Bookworm (Debian 12):
- `rust:1.89.0-bullseye` → `rust:1.89.0-bookworm`
- `debian:bullseye-slim` → `debian:bookworm-slim`  
- `lukemathwalker/cargo-chef:latest-rust-1.89.0-bullseye` → `latest-rust-1.89.0-bookworm`

## Changes
- **10 Dockerfiles updated** (Periphery, Core, CLI, Binaries)
- **Rust version unchanged** at 1.89.0 to avoid dependency issues
- Only OS layer updated for security patches

## Testing
✅ Successfully built and tested `komodo-periphery:1.19.5` & `komodo-core:1.19.5` with Bookworm
✅ All dependencies compatible with Debian 12
✅ No breaking changes in functionality

## Note
This PR addresses security vulnerabilities. Feel free to use it if it fits your release cycle - no pressure!

---

**Risk:** Minimal - only OS security updates, no Rust version changes
