### PR TITLE
feat: Add Command Wrapper for Stack compose deployment

### DIFF
--- a/bin/periphery/src/api/compose/mod.rs
+++ b/bin/periphery/src/api/compose/mod.rs
@@ -658,9 +658,14 @@ impl Resolve<super::Args> for ComposeUp {
 
     // Run compose up
     let extra_args = format_extra_args(&stack.config.extra_args);
-    let command = format!(
+    let mut command = format!(
       "{docker_compose} -p {project_name} -f {file_args}{env_file_args} up -d{extra_args}{service_args}",
     );
+    
+    // Apply wrapper if configured
+    if !stack.config.compose_cmd_wrapper.is_empty() {
+      command = stack.config.compose_cmd_wrapper.replace("[[COMPOSE_COMMAND]]", &command);
+    }
 
     let span = info_span!("RunComposeUp");
     let Some(log) = run_komodo_command_with_sanitization(

--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -517,6 +517,17 @@ pub struct StackConfig {
   #[builder(default)]
   pub build_extra_args: Vec<String>,
 
+  /// Optional command wrapper for secrets management tools.
+  /// Wraps the docker compose up command with a prefix command.
+  /// Use [[COMPOSE_COMMAND]] as placeholder for the full compose command.
+  ///
+  /// Examples:
+  /// - "op run -- [[COMPOSE_COMMAND]]" (1password CLI)
+  /// - "sops exec-file --no-fifo /path/to/secret.env '[[COMPOSE_COMMAND]]'" (sops)
+  #[serde(default)]
+  #[builder(default)]
+  pub compose_cmd_wrapper: String,
+
   /// Ignore certain services declared in the compose file when checking
   /// the stack status. For example, an init service might be exited, but the
   /// stack should be healthy. This init service should be in `ignore_services`
@@ -619,6 +630,7 @@ impl Default for StackConfig {
       run_build: Default::default(),
       destroy_before_deploy: Default::default(),
       build_extra_args: Default::default(),
+      compose_cmd_wrapper: Default::default(),
       skip_secret_interp: Default::default(),
       linked_repo: Default::default(),
       git_provider: default_git_provider(),

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -2375,6 +2375,16 @@ export interface StackConfig {
 	 */
 	build_extra_args?: string[];
 	/**
+	 * Optional command wrapper for secrets management tools.
+	 * Wraps the docker compose up command with a prefix command.
+	 * Use [[COMPOSE_COMMAND]] as placeholder for the full compose command.
+	 * 
+	 * Examples:
+	 * - "op run -- [[COMPOSE_COMMAND]]" (1password CLI)
+	 * - "sops exec-file --no-fifo /path/to/secret.env '[[COMPOSE_COMMAND]]'" (sops)
+	 */
+	compose_cmd_wrapper?: string;
+	/**
 	 * Ignore certain services declared in the compose file when checking
 	 * the stack status. For example, an init service might be exited, but the
 	 * stack should be healthy. This init service should be in `ignore_services`
@@ -4284,12 +4294,6 @@ export interface AwsBuilderConfig {
 	/** The size of the builder volume in gb */
 	volume_gb: number;
 	/**
-	 * The port periphery will be running on.
-	 * Default: `8120`
-	 */
-	port: number;
-	use_https: boolean;
-	/**
 	 * The EC2 ami id to create.
 	 * The ami should have the periphery client configured to start on startup,
 	 * and should have the necessary github / dockerhub accounts configured.
@@ -4316,6 +4320,12 @@ export interface AwsBuilderConfig {
 	security_group_ids?: string[];
 	/** The user data to deploy the instance with. */
 	user_data?: string;
+	/**
+	 * The port periphery will be running on.
+	 * Default: `8120`
+	 */
+	port: number;
+	use_https: boolean;
 	/**
 	 * An expected public key associated with Periphery private key.
 	 * If empty, doesn't validate Periphery public key.

--- a/frontend/src/components/resources/stack/config.tsx
+++ b/frontend/src/components/resources/stack/config.tsx
@@ -369,6 +369,26 @@ export const StackConfig = ({
       },
     },
     {
+      label: "Command Wrapper",
+      description:
+        "Optional wrapper to execute 'docker compose up -d' as a subcommand of tools like secrets management.",
+      components: {
+        compose_cmd_wrapper: (value, set) => (
+          <MonacoEditor
+            value={
+              value ||
+              "# Example: sops exec-env .encrypted.env '[[COMPOSE_COMMAND]]'\n# [[COMPOSE_COMMAND]] is a placeholder for the full compose command\n"
+            }
+            language="shell"
+            onValueChange={(compose_cmd_wrapper) =>
+              set({ compose_cmd_wrapper })
+            }
+            readOnly={disabled}
+          />
+        ),
+      },
+    },
+    {
       label: "Extra Args",
       labelHidden: true,
       components: {


### PR DESCRIPTION
Added optional `compose_cmd_wrapper` field to Stack configuration, allowing users to wrap the `docker compose up -d` command with external tools like secrets management CLIs.

## Use Cases

- **1password CLI**: `op run -- [[COMPOSE_COMMAND]]`
- **sops**: `sops exec-env .encrypted.env '[[COMPOSE_COMMAND]]'`
- **Custom tools**: Any CLI tool that needs to inject secrets or environment variables

## Changes

- **Backend**: Added `compose_cmd_wrapper: String` field to `StackConfig`
- **Logic**: Applies wrapper by replacing `[[COMPOSE_COMMAND]]` placeholder with the full compose command
- **Frontend**: Added "Command Wrapper" Monaco editor in Stack config (positioned after Post Deploy)
- **Types**: Regenerated TypeScript types

## Example
```toml
compose_cmd_wrapper = """
sops exec-env ../.encrypted.env '[[COMPOSE_COMMAND]]'"""
```
Executes as:
```bash
sops exec-env .encrypted.env 'docker compose -p myproject -f compose.yaml up -d' ## Files Modified
```

<img width="1538" height="1026" alt="image" src="https://github.com/user-attachments/assets/9994434d-5665-4657-8f8c-f83e6d75006a" />
