### PR TITLE
fix: Add interpolation and [[COMPOSE_COMMAND]] validation for compose_cmd_wrapper

### DIFF
--- a/bin/periphery/src/api/compose/mod.rs
+++ b/bin/periphery/src/api/compose/mod.rs
@@ -670,6 +670,13 @@ impl Resolve<super::Args> for ComposeUp {
     let compose_cmd_wrapper =
       parse_multiline_command(&stack.config.compose_cmd_wrapper);
     if !compose_cmd_wrapper.is_empty() {
+      if !compose_cmd_wrapper.contains("[[COMPOSE_COMMAND]]") {
+        res.logs.push(Log::error(
+          "Compose Command Wrapper",
+          "compose_cmd_wrapper is configured but does not contain [[COMPOSE_COMMAND]] placeholder. The placeholder is required to inject the compose command.".to_string(),
+        ));
+        return Ok(res);
+      }
       command =
         compose_cmd_wrapper.replace("[[COMPOSE_COMMAND]]", &command);
     }

--- a/lib/interpolate/src/lib.rs
+++ b/lib/interpolate/src/lib.rs
@@ -38,6 +38,7 @@ impl<'a> Interpolator<'a> {
       .interpolate_string(&mut stack.config.environment)?
       .interpolate_string(&mut stack.config.pre_deploy.command)?
       .interpolate_string(&mut stack.config.post_deploy.command)?
+      .interpolate_string(&mut stack.config.compose_cmd_wrapper)?
       .interpolate_extra_args(&mut stack.config.extra_args)?
       .interpolate_extra_args(&mut stack.config.build_extra_args)
   }


### PR DESCRIPTION
## Changes

**Interpolation** (`lib/interpolate/src/lib.rs`):
- Added `compose_cmd_wrapper` to `interpolate_stack()` to support variable/secret interpolation

**Validation** (`bin/periphery/src/api/compose/mod.rs`):
- Added check to ensure `[[COMPOSE_COMMAND]]` placeholder exists before execution
- Returns clear error message if placeholder is missing