### PR TITLE
KOMODO_OIDC_ALLOW_ADDITIONAL_AUDIENCES environment variable to allow an arbitrary list of audiences as long as client_id is present

### DIFF
--- a/bin/core/src/auth/oidc/client.rs
+++ b/bin/core/src/auth/oidc/client.rs
@@ -174,11 +174,13 @@ impl OidcClient {
     let verifier = self.0.id_token_verifier();
     let additional_audiences =
       &core_config().oidc_additional_audiences;
-    let verifier = if additional_audiences.is_empty() {
+    let allow_additional_audiences = 
+      &core_config().oidc_allow_additional_audiences;
+    let verifier = if additional_audiences.is_empty() && !allow_additional_audiences {      
       verifier
     } else {
       verifier.set_other_audience_verifier_fn(|aud| {
-        additional_audiences.contains(aud)
+        additional_audiences.contains(aud) || *allow_additional_audiences
       })
     };
 

--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -285,6 +285,9 @@ pub fn core_config() -> &'static CoreConfig {
         env.komodo_oidc_additional_audiences,
       )
       .unwrap_or(config.oidc_additional_audiences),
+      oidc_allow_additional_audiences: env
+        .komodo_oidc_allow_additional_audiences
+        .unwrap_or(config.oidc_allow_additional_audiences),
       google_oauth: OauthCredentials {
         enabled: env
           .komodo_google_oauth_enabled

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -197,7 +197,8 @@ pub struct Env {
   pub komodo_oidc_additional_audiences: Option<Vec<String>>,
   /// Override `oidc_additional_audiences` from file
   pub komodo_oidc_additional_audiences_file: Option<PathBuf>,
-
+  /// Override `oidc_allow_additional_audiences`
+  pub komodo_oidc_allow_additional_audiences: Option<bool>,
   /// Override `google_oauth.enabled`
   pub komodo_google_oauth_enabled: Option<bool>,
   /// Override `google_oauth.id`
@@ -520,6 +521,13 @@ pub struct CoreConfig {
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub oidc_additional_audiences: Vec<String>,
 
+  /// Allow all additional audiences that may be set other than `client_id`.
+  /// The OIDC spec only requires that the `client_id` audience is present OR 
+  /// that the client trust additional audiences.  This will allow the presence of
+  /// additional audiences without verifying them specifically.
+  #[serde(default)]
+  pub oidc_allow_additional_audiences: bool, 
+
   // =========
   // = Oauth =
   // =========
@@ -817,6 +825,7 @@ impl Default for CoreConfig {
       oidc_client_secret: Default::default(),
       oidc_use_full_email: Default::default(),
       oidc_additional_audiences: Default::default(),
+      oidc_allow_additional_audiences: Default::default(),
       google_oauth: Default::default(),
       github_oauth: Default::default(),
       auth_rate_limit_disabled: Default::default(),
@@ -913,6 +922,7 @@ impl CoreConfig {
         .iter()
         .map(|aud| empty_or_redacted(aud))
         .collect(),
+      oidc_allow_additional_audiences: config.oidc_allow_additional_audiences,
       google_oauth: OauthCredentials {
         enabled: config.google_oauth.enabled,
         id: empty_or_redacted(&config.google_oauth.id),


### PR DESCRIPTION
When setting up Komodo with my IdP (Zitadel cloud), I realized Zitadel returns many audience entries depending on configured projects, authorizations, etc.  It was effectively pointless to try and authorize each audience value since they may regularly and individually be added or removed from the token.

I added an environment variable to automatically trust any audience included in the token, AS LONG AS the client_id is one of them.  My understanding of the OIDC spec is that a client MUST reject a token that does not include the client_id, but MAY reject a token with additional audiences.

There is no change to the logic of including additional audiences other than the fact that a "true" value for KOMODO_OIDC_ALLOW_ADDITIONAL_AUDIENCES will allow any audiences.  A "false" (the default) value will continue to function as it does today