### PR TITLE
Fix: E0716 temporary value dropped while borrowed

### DIFF
--- a/bin/core/src/alert/discord.rs
+++ b/bin/core/src/alert/discord.rs
@@ -230,14 +230,13 @@ pub async fn send_alert(
       )
     }
     AlertData::Custom { message, details } => {
-      format!(
-        "{level} | {message}{}",
-        if details.is_empty() {
-          format_args!("")
-        } else {
-          format_args!("\n{details}")
-        }
-      )
+      let details_str = if details.is_empty() {
+        String::new()
+      } else {
+        format!("\n{details}")
+      };
+
+      format!("{level} | {message}{details_str}")
     }
     AlertData::None {} => Default::default(),
   };

--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -474,14 +474,13 @@ fn standard_alert_content(alert: &Alert) -> String {
       )
     }
     AlertData::Custom { message, details } => {
-      format!(
-        "{level} | {message}{}",
-        if details.is_empty() {
-          format_args!("")
-        } else {
-          format_args!("\n{details}")
-        }
-      )
+      let details_str = if details.is_empty() {
+        String::new()
+      } else {
+        format!("\n{details}")
+      };
+
+      format!("{level} | {message}{details_str}")
     }
     AlertData::None {} => Default::default(),
   }


### PR DESCRIPTION
Updated the AlertData::Custom formatting logic to resolve a compiler error introduced in newer Rust versions (1.92+). The previous use of format_args! within an if/else block created temporary values that were dropped before they could be used by the outer format! macro.