### PR TITLE
Fix: Hotkey bindings interfere with typing in Monaco editor

### DIFF
--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -501,9 +501,14 @@ export const useLocalStorage = <T>(
 export const useKeyListener = (listenKey: string, onPress: () => void) => {
   useEffect(() => {
     const keydown = (e: KeyboardEvent) => {
-      // This will ignore Shift + listenKey if it is sent from input / textarea
-      const target = e.target as any;
-      if (target.matches("input") || target.matches("textarea")) return;
+      // Ignore hotkeys when user is typing in an input, textarea, select, or contentEditable element (e.g., Monaco editor)
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable
+      ) return;
 
       if (e.key === listenKey) {
         e.preventDefault();
@@ -518,9 +523,14 @@ export const useKeyListener = (listenKey: string, onPress: () => void) => {
 export const useShiftKeyListener = (listenKey: string, onPress: () => void) => {
   useEffect(() => {
     const keydown = (e: KeyboardEvent) => {
-      // This will ignore Shift + listenKey if it is sent from input / textarea
-      const target = e.target as any;
-      if (target.matches("input") || target.matches("textarea")) return;
+      // Ignore hotkeys when user is typing in an input, textarea, select, or contentEditable element (e.g., Monaco editor)
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable
+      ) return;
 
       if (e.shiftKey && e.key === listenKey) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
Fixes hotkey bindings (like Shift+D for Deployments) triggering while typing in the compose text box and other Monaco editor inputs.

## Root Cause
The useKeyListener and useShiftKeyListener hooks only checked for standard input and textarea elements. However, Monaco editor uses contentEditable divs, which were not being filtered.

## Changes
- Updated useKeyListener to also check target.isContentEditable and SELECT elements
- Updated useShiftKeyListener with the same fix
- Aligned with the existing pattern used in usePromptHotkeys

## Testing
- Verified hotkeys no longer trigger when typing in compose/editor fields
- Confirmed hotkeys still work normally outside of input contexts

Closes #1135