### PR TITLE
fix: escape regex special chars in container name matching

### DIFF
--- a/bin/core/src/stack/mod.rs
+++ b/bin/core/src/stack/mod.rs
@@ -43,7 +43,8 @@ pub async fn get_stack_and_server(
 pub fn compose_container_match_regex(
   container_name: &str,
 ) -> anyhow::Result<Regex> {
-  let regex = format!("^{container_name}-?[0-9]*$");
+  let escaped_name = regex::escape(container_name);
+  let regex = format!("^{escaped_name}-?[0-9]*$");
   Regex::new(&regex).with_context(|| {
     format!("failed to construct valid regex from {regex}")
   })


### PR DESCRIPTION
## Summary
Fixes container name regex construction to properly escape special characters like `\$`, `{`, `}`.

## Root Cause
The regex pattern was constructed using raw container names that may contain regex metacharacters (e.g., `\`). The `\$` and `{` characters have special meaning in regex, causing a parse error:

\\\
regex parse error: ^\_portainer-?[0-9]*\$
                      ^
error: repetition quantifier expects a valid decimal
\\\

## Changes
- Added `regex::escape()` call for container names before pattern construction in `compose_container_match_regex`

## Testing
- Tested with compose files using `\` in container names

Closes #1119