### PR TITLE
feat: support markdown link formatting in stack headers

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -269,3 +269,36 @@ export const file_contents_empty = (contents?: string) => {
       .filter((line) => line.length !== 0 && !line.startsWith("#")).length === 0
   );
 };
+
+/**
+ * Parse a markdown-style link and extract the display text and URL.
+ * Supports format: [Display Text](https://example.com)
+ * Returns { text, url } if valid markdown link, or { text: input, url: input } for plain URLs.
+ */
+export const parseMarkdownLink = (
+  input: string
+): { text: string; url: string } => {
+  if (!input) return { text: "", url: "" };
+
+  const trimmed = input.trim();
+
+  // Match markdown link pattern: [text](url)
+  // Uses a non-greedy match for text to handle nested brackets correctly
+  const markdownLinkRegex = /^\[([^\]]+)\]\(([^)]+)\)$/;
+  const match = trimmed.match(markdownLinkRegex);
+
+  if (match) {
+    const [, text, url] = match;
+    // Validate that the URL looks reasonable (has protocol or starts with /)
+    if (
+      url.startsWith("http://") ||
+      url.startsWith("https://") ||
+      url.startsWith("/")
+    ) {
+      return { text: text.trim(), url: url.trim() };
+    }
+  }
+
+  // Not a markdown link, return the input as both text and URL
+  return { text: trimmed, url: trimmed };
+};

--- a/frontend/src/pages/resource.tsx
+++ b/frontend/src/pages/resource.tsx
@@ -13,7 +13,11 @@ import {
   useResourceParamType,
   useSetTitle,
 } from "@lib/hooks";
-import { SETTINGS_RESOURCES, usableResourcePath } from "@lib/utils";
+import {
+  parseMarkdownLink,
+  SETTINGS_RESOURCES,
+  usableResourcePath,
+} from "@lib/utils";
 import { Types } from "komodo_client";
 import { UsableResource } from "@types";
 import { Button } from "@ui/button";
@@ -148,19 +152,22 @@ export const ResourceHeader = ({
         </div>
         {links && links.length > 0 && (
           <div className="flex items-center gap-x-4 gap-y-2 flex-wrap px-4 py-0">
-            {links?.map((link) => (
-              <a
-                key={link}
-                target="_blank"
-                href={link}
-                className="flex gap-2 items-center pr-4 text-sm border-r cursor-pointer hover:underline last:pr-0 last:border-none"
-              >
-                <LinkIcon className="w-4" />
-                <div className="max-w-[150px] lg:max-w-[250px] text-nowrap overflow-hidden overflow-ellipsis">
-                  {link}
-                </div>
-              </a>
-            ))}
+            {links?.map((link) => {
+              const { text, url } = parseMarkdownLink(link);
+              return (
+                <a
+                  key={link}
+                  target="_blank"
+                  href={url}
+                  className="flex gap-2 items-center pr-4 text-sm border-r cursor-pointer hover:underline last:pr-0 last:border-none"
+                >
+                  <LinkIcon className="w-4" />
+                  <div className="max-w-[150px] lg:max-w-[250px] text-nowrap overflow-hidden overflow-ellipsis">
+                    {text}
+                  </div>
+                </a>
+              );
+            })}
           </div>
         )}
         <div className="flex items-center gap-2 flex-wrap p-4 pt-0">


### PR DESCRIPTION
## Summary
Adds support for markdown-style link formatting `[text](url)` in stack headers.

## Changes
- Added `parseMarkdownLink` utility function in `frontend/src/lib/utils.ts`
- Updated link rendering in `ResourceHeader` component to parse and display markdown links
- Links render as clickable text instead of raw URLs
- Plain URLs continue to work as before (backward compatible)

## Testing
- Tested with various markdown link formats
- Verified edge cases (malformed links, special characters, plain URLs)

Closes #1071