### PR TITLE
feat: add IPv4 column to containers table

### DIFF
--- a/bin/periphery/src/docker/containers.rs
+++ b/bin/periphery/src/docker/containers.rs
@@ -52,12 +52,30 @@ impl DockerClient {
             .and_then(|config| config.network_mode),
           networks: container
             .network_settings
+            .as_ref()
             .and_then(|settings| {
-              settings.networks.map(|networks| {
+              settings.networks.as_ref().map(|networks| {
                 let mut keys =
-                  networks.into_keys().collect::<Vec<_>>();
+                  networks.keys().cloned().collect::<Vec<_>>();
                 keys.sort();
                 keys
+              })
+            })
+            .unwrap_or_default(),
+          ip_addresses: container
+            .network_settings
+            .and_then(|settings| {
+              settings.networks.map(|networks| {
+                let mut entries: Vec<_> = networks.into_iter().collect();
+                entries.sort_by(|a, b| a.0.cmp(&b.0));
+                entries
+                  .into_iter()
+                  .filter_map(|(_, endpoint)| {
+                    endpoint
+                      .ip_address
+                      .filter(|ip| !ip.is_empty())
+                  })
+                  .collect()
               })
             })
             .unwrap_or_default(),

--- a/client/core/rs/src/entities/docker/container.rs
+++ b/client/core/rs/src/entities/docker/container.rs
@@ -49,6 +49,9 @@ pub struct ContainerListItem {
   /// The network names attached to container
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub networks: Vec<String>,
+  /// The IPv4 addresses for each network (in same order as networks)
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub ip_addresses: Vec<String>,
   /// Port mappings for the container
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub ports: Vec<Port>,

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -3470,6 +3470,8 @@ export interface ContainerListItem {
 	network_mode?: string;
 	/** The network names attached to container */
 	networks?: string[];
+	/** The IPv4 addresses for each network (in same order as networks) */
+	ip_addresses?: string[];
 	/** Port mappings for the container */
 	ports?: Port[];
 	/** The volume names attached to container */

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -3502,6 +3502,8 @@ export interface ContainerListItem {
     network_mode?: string;
     /** The network names attached to container */
     networks?: string[];
+    /** The IPv4 addresses for each network (in same order as networks) */
+    ip_addresses?: string[];
     /** Port mappings for the container */
     ports?: Port[];
     /** The volume names attached to container */

--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -864,6 +864,29 @@ export const DockerContainersSection = ({
                 ),
               },
               {
+                accessorKey: "ip_addresses.0",
+                size: 140,
+                header: ({ column }) => (
+                  <SortableHeader column={column} title="IPv4" />
+                ),
+                cell: ({ row }) => {
+                  const ips = row.original.ip_addresses ?? [];
+                  if (ips.length === 0) {
+                    return <span className="text-muted-foreground">-</span>;
+                  }
+                  if (ips.length === 1) {
+                    return <span className="font-mono text-sm">{ips[0]}</span>;
+                  }
+                  return (
+                    <div className="flex flex-col gap-1">
+                      {ips.map((ip, i) => (
+                        <span key={i} className="font-mono text-sm">{ip}</span>
+                      ))}
+                    </div>
+                  );
+                },
+              },
+              {
                 accessorKey: "networks.0",
                 size: 200,
                 header: ({ column }) => (

--- a/frontend/src/pages/containers.tsx
+++ b/frontend/src/pages/containers.tsx
@@ -188,6 +188,29 @@ export default function ContainersPage() {
               },
             },
             {
+              accessorKey: "ip_addresses.0",
+              size: 140,
+              header: ({ column }) => (
+                <SortableHeader column={column} title="IPv4" />
+              ),
+              cell: ({ row }) => {
+                const ips = row.original.ip_addresses ?? [];
+                if (ips.length === 0) {
+                  return <span className="text-muted-foreground">-</span>;
+                }
+                if (ips.length === 1) {
+                  return <span className="font-mono text-sm">{ips[0]}</span>;
+                }
+                return (
+                  <div className="flex flex-col gap-1">
+                    {ips.map((ip, i) => (
+                      <span key={i} className="font-mono text-sm">{ip}</span>
+                    ))}
+                  </div>
+                );
+              },
+            },
+            {
               accessorKey: "networks.0",
               size: 200,
               header: ({ column }) => (


### PR DESCRIPTION
## Summary
Adds an IPv4 address column to the Containers page table, similar to Portainer.

## Changes
- Added \ip_addresses\ field to \ContainerListItem\ type (Rust + TypeScript)
- Modified periphery to extract IP addresses from Docker network settings
- Added IPv4 column to containers table on both the main Containers page and the server-specific container lists
- Handles containers with multiple networks by displaying each IP on its own line
- Shows \-\ for containers without IP addresses (e.g., host network mode)

## Testing
- Tested with containers on various network configurations

Closes #1110