### PR TITLE
fix: prevent tag overflow on dashboard cards

### DIFF
--- a/frontend/src/pages/home/dashboard.tsx
+++ b/frontend/src/pages/home/dashboard.tsx
@@ -197,7 +197,7 @@ const RecentCard = ({
         </div>
       </div>
 
-      <div className="flex flex-row gap-2 w-full py-1">
+      <div className="flex flex-row flex-wrap gap-1 w-full overflow-hidden max-h-6">
         <TagsWithBadge tag_ids={tags} />
       </div>
     </Link>


### PR DESCRIPTION
Fixes #1000

## Problem
Tags on Procedures/Stacks/Builds dashboard cards overflow and get clipped when there are too many tags.

## Solution
Added CSS flex-wrap and overflow handling to the tags container in dashboard cards:
- \lex-wrap\ allows tags to wrap to next line if space permits
- \overflow-hidden\ prevents tags from overflowing the card bounds
- \max-h-6\ limits the tags area height to keep cards compact
- Reduced gap from \gap-2\ to \gap-1\ for tighter tag spacing

This ensures tags stay within card bounds while still displaying as many as will fit.