### PR TITLE
fix: URL encode branch names in webhook URLs

### DIFF
--- a/frontend/src/components/resources/action/config.tsx
+++ b/frontend/src/components/resources/action/config.tsx
@@ -326,7 +326,7 @@ export const ActionConfig = ({ id }: { id: string }) => {
                 <ConfigItem label="Webhook Url - Run">
                   <CopyWebhook
                     integration={webhook_integration}
-                    path={`/action/${id_or_name === "Id" ? id : encodeURIComponent(name ?? "...")}/${branch}`}
+                    path={`/action/${id_or_name === "Id" ? id : encodeURIComponent(name ?? "...")}/${encodeURIComponent(branch)}`}
                   />
                 </ConfigItem>
               ),

--- a/frontend/src/components/resources/procedure/config.tsx
+++ b/frontend/src/components/resources/procedure/config.tsx
@@ -402,7 +402,7 @@ export const ProcedureConfig = ({ id }: { id: string }) => {
                 <ConfigItem label="Webhook Url - Run">
                   <CopyWebhook
                     integration={webhook_integration}
-                    path={`/procedure/${id_or_name === "Id" ? id : encodeURIComponent(name ?? "...")}/${branch}`}
+                    path={`/procedure/${id_or_name === "Id" ? id : encodeURIComponent(name ?? "...")}/${encodeURIComponent(branch)}`}
                   />
                 </ConfigItem>
               ),


### PR DESCRIPTION
## Summary

Branch names containing special characters like \/\ (e.g., \eat/feature-name\) were breaking webhook URLs because the branch wasn't being URL-encoded when constructing the webhook path.

## Changes

- Applied \encodeURIComponent()\ to the branch parameter when constructing webhook URLs for both Procedure and Action resources

## Files Modified

- \rontend/src/components/resources/procedure/config.tsx\
- \rontend/src/components/resources/action/config.tsx\

## Testing

A branch like \eat/feature-name\ will now produce the URL path \/procedure/{id}/feat%2Ffeature-name\ instead of the broken \/procedure/{id}/feat/feature-name\. The axum backend router will automatically decode the URL path parameters, so the branch will be correctly extracted.

Closes #1007