### PR TITLE
feat: add -y flag to run procedure command

### DIFF
--- a/client/core/rs/src/entities/config/cli/args/mod.rs
+++ b/client/core/rs/src/entities/config/cli/args/mod.rs
@@ -104,7 +104,7 @@ pub struct Execute {
   #[arg(long, short = 's')]
   pub secret: Option<String>,
   /// Always continue on user confirmation prompts.
-  #[arg(long, short = 'y', default_value_t = false)]
+  #[arg(long, short = 'y', default_value_t = false, global = true)]
   pub yes: bool,
 }
 


### PR DESCRIPTION
Makes the -y/--yes flag global so it can be placed after the subcommand, enabling non-interactive procedure execution:

\\\ash
km run procedure my-procedure -y
\\\

Previously, the -y flag had to be placed before the subcommand (e.g., \km execute -y run-procedure my-procedure\), which was inconsistent with user expectations.

Closes #1002