### PR TITLE
fix: resolve copy on click clipboard error

### DIFF
--- a/frontend/src/components/config/env_vars.tsx
+++ b/frontend/src/components/config/env_vars.tsx
@@ -1,4 +1,5 @@
 import { SecretSelector } from "@components/config/util";
+import { copyToClipboard } from "@components/util";
 import { useRead } from "@lib/hooks";
 import { Types } from "komodo_client";
 import { useToast } from "@ui/use-toast";
@@ -47,10 +48,12 @@ const SecretsView = ({
         <SecretSelector
           type="Variable"
           keys={variables.map((v) => v.name)}
-          onSelect={(variable) => {
+          onSelect={async (variable) => {
             if (!variable) return;
-            navigator.clipboard.writeText("[[" + variable + "]]");
-            toast({ title: "Copied selection" });
+            const success = await copyToClipboard("[[" + variable + "]]");
+            if (success) {
+              toast({ title: "Copied selection" });
+            }
           }}
           disabled={false}
           side="right"
@@ -61,10 +64,12 @@ const SecretsView = ({
         <SecretSelector
           type="Secret"
           keys={secrets}
-          onSelect={(secret) => {
+          onSelect={async (secret) => {
             if (!secret) return;
-            navigator.clipboard.writeText("[[" + secret + "]]");
-            toast({ title: "Copied selection" });
+            const success = await copyToClipboard("[[" + secret + "]]");
+            if (success) {
+              toast({ title: "Copied selection" });
+            }
           }}
           disabled={false}
           side="right"

--- a/frontend/src/components/group-actions.tsx
+++ b/frontend/src/components/group-actions.tsx
@@ -18,7 +18,7 @@ import { Input } from "@ui/input";
 import { Types } from "komodo_client";
 import { ChevronDown, CheckCircle } from "lucide-react";
 import { useState } from "react";
-import { ConfirmButton } from "./util";
+import { ConfirmButton, copyToClipboard } from "./util";
 import { useToast } from "@ui/use-toast";
 import { usableResourceExecuteKey } from "@lib/utils";
 
@@ -149,9 +149,11 @@ const GroupActionDialog = ({
           {!action.startsWith("Refresh") && (
             <>
               <p
-                onClick={() => {
-                  navigator.clipboard.writeText(formatted);
-                  toast({ title: `Copied "${formatted}" to clipboard!` });
+                onClick={async () => {
+                  const success = await copyToClipboard(formatted);
+                  if (success) {
+                    toast({ title: `Copied "${formatted}" to clipboard!` });
+                  }
                 }}
                 className="cursor-pointer"
               >

--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -93,6 +93,20 @@ import {
 } from "@ui/select";
 import { useServer } from "./resources/server";
 
+/**
+ * Safely copy text to clipboard with error handling.
+ * The clipboard API is async and may fail in certain contexts.
+ */
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    console.error("Failed to copy to clipboard");
+    return false;
+  }
+};
+
 export const ActionButton = forwardRef<
   HTMLButtonElement,
   {
@@ -243,9 +257,11 @@ export const ActionWithDialog = ({
         </DialogHeader>
         <div className="flex flex-col gap-4 my-4">
           <p
-            onClick={() => {
-              navigator.clipboard.writeText(name);
-              toast({ title: `Copied "${name}" to clipboard!` });
+            onClick={async () => {
+              const success = await copyToClipboard(name);
+              if (success) {
+                toast({ title: `Copied "${name}" to clipboard!` });
+              }
             }}
             className="cursor-pointer"
           >
@@ -372,10 +388,12 @@ export const CopyButton = ({
       className={cn("shrink-0", className)}
       size="icon"
       variant="outline"
-      onClick={() => {
+      onClick={async () => {
         if (!content) return;
-        navigator.clipboard.writeText(content);
-        set(true);
+        const success = await copyToClipboard(content);
+        if (success) {
+          set(true);
+        }
       }}
       disabled={!content}
     >


### PR DESCRIPTION
## Summary
Fixes the copy-on-click functionality that was throwing console errors and failing to copy text.

## Problem
The clipboard API (
avigator.clipboard.writeText()) is asynchronous and returns a Promise. The previous implementation wasn't handling this properly, causing:
- Unhandled promise rejections
- Toast notifications showing even when copy failed
- Console errors when clipboard access was denied

## Solution
- Added a copyToClipboard helper function with proper async/await and error handling
- Updated all clipboard operations to use the new helper
- Toast notifications now only show on successful copy operations

## Files Changed
- rontend/src/components/util.tsx - Added helper function and fixed usages
- rontend/src/components/config/env_vars.tsx - Fixed clipboard calls
- rontend/src/components/group-actions.tsx - Fixed clipboard calls

Closes #1047