### PR TITLE
fix: trim extra newlines from post deploy commands

### DIFF
--- a/client/core/rs/src/deserializers/command.rs
+++ b/client/core/rs/src/deserializers/command.rs
@@ -1,0 +1,33 @@
+use serde::{Deserializer, de::Visitor};
+
+/// Using this ensures the command string is trimmed of trailing whitespace.
+/// Unlike file_contents_deserializer, this does NOT add a trailing newline,
+/// as commands should not have trailing newlines when executed.
+pub fn command_deserializer<'de, D>(
+  deserializer: D,
+) -> Result<String, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  deserializer.deserialize_any(CommandVisitor)
+}
+
+struct CommandVisitor;
+
+impl Visitor<'_> for CommandVisitor {
+  type Value = String;
+
+  fn expecting(
+    &self,
+    formatter: &mut std::fmt::Formatter,
+  ) -> std::fmt::Result {
+    write!(formatter, "string")
+  }
+
+  fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+  where
+    E: serde::de::Error,
+  {
+    Ok(v.trim_end().to_string())
+  }
+}

--- a/client/core/rs/src/deserializers/mod.rs
+++ b/client/core/rs/src/deserializers/mod.rs
@@ -1,5 +1,6 @@
 //! Deserializers for custom behavior and backward compatibility.
 
+mod command;
 mod conversion;
 mod environment;
 mod file_contents;
@@ -11,6 +12,7 @@ mod permission;
 mod string_list;
 mod term_signal_labels;
 
+pub use command::*;
 pub use conversion::*;
 pub use environment::*;
 pub use file_contents::*;

--- a/client/core/rs/src/entities/mod.rs
+++ b/client/core/rs/src/entities/mod.rs
@@ -17,7 +17,7 @@ use strum::{AsRefStr, Display, EnumString};
 use typeshare::typeshare;
 
 use crate::{
-  deserializers::file_contents_deserializer, entities::update::Log,
+  deserializers::command_deserializer, entities::update::Log,
   parsers::parse_key_value_list,
 };
 
@@ -182,7 +182,7 @@ pub struct __Serror {
 pub struct SystemCommand {
   #[serde(default)]
   pub path: String,
-  #[serde(default, deserialize_with = "file_contents_deserializer")]
+  #[serde(default, deserialize_with = "command_deserializer")]
   pub command: String,
 }
 


### PR DESCRIPTION
## Summary

Fixes #1052 - Post Deploy Commands always adds extra line causing terminal errors.

## Problem

The \SystemCommand\ struct was using \ile_contents_deserializer\ which intentionally adds a trailing newline to ensure proper file formatting (POSIX standard for files). However, shell commands should not have trailing newlines as this causes terminal errors like \Error opening terminal: unknown.\

Every time a user saved a Post Deploy command, the deserializer would:
1. Trim trailing whitespace
2. Add a trailing newline

This resulted in an extra blank line appearing in the Post Deploy section that would reappear even after the user deleted it.

## Solution

Added a new \command_deserializer\ that trims trailing whitespace without adding a newline, and updated \SystemCommand\ to use it instead of \ile_contents_deserializer\.

## Changes

- Added \client/core/rs/src/deserializers/command.rs\ - new deserializer that trims but doesn't add newlines
- Updated \client/core/rs/src/deserializers/mod.rs\ - export the new deserializer
- Updated \client/core/rs/src/entities/mod.rs\ - changed \SystemCommand\ to use \command_deserializer\

## Testing

- Commands should no longer have a trailing newline added when saved
- The 'Error opening terminal: unknown' error should be resolved