### PR TITLE
fix: hide templates from recently viewed section

### DIFF
--- a/frontend/src/pages/home/dashboard.tsx
+++ b/frontend/src/pages/home/dashboard.tsx
@@ -96,11 +96,20 @@ export default function Dashboard() {
 const ResourceRow = ({ type }: { type: UsableResource }) => {
   const _recents = useUser().data?.recents?.[type]?.slice(0, 6);
   const _resources = useRead(`List${type}s`, {}).data;
+  
+  // Helper to check if a resource ID corresponds to a template
+  const isTemplate = (id: string) =>
+    _resources?.find((r) => r.id === id)?.template ?? false;
+  
+  // Filter recents to exclude templates and non-existent resources
   const recents = _recents?.filter(
-    (recent) => !_resources?.every((resource) => resource.id !== recent),
+    (recent) =>
+      !_resources?.every((resource) => resource.id !== recent) &&
+      !isTemplate(recent),
   );
+  // Filter resources to exclude templates and already-shown recents
   const resources = _resources
-    ?.filter((r) => !recents?.includes(r.id))
+    ?.filter((r) => !recents?.includes(r.id) && !r.template)
     .map((r) => r.id);
   const ids = [
     ...(recents ?? []),


### PR DESCRIPTION
## Summary

Hides templates from the "Recently Viewed" section on the dashboard, as requested in #1014.

## Changes

Modified the `ResourceRow` component in `dashboard.tsx` to filter out template resources from both:
- The user's recent history (`recents`)
- The fallback resources list

Templates will still appear in their respective resource pages and can be identified by the template marker.

## Testing

1. Create some template resources (servers, stacks, etc.)
2. Visit those templates so they appear in recently viewed
3. Return to the dashboard
4. Templates should no longer appear in the "Recently Viewed" cards

Closes #1014
