### PR TITLE
feat: add option to remove volumes on stack destroy

### DIFF
--- a/bin/core/src/api/execute/stack.rs
+++ b/bin/core/src/api/execute/stack.rs
@@ -923,6 +923,7 @@ impl super::BatchExecute for BatchDestroyStack {
       stack,
       services: Vec::new(),
       remove_orphans: false,
+      remove_volumes: false,
       stop_time: None,
     })
   }
@@ -952,7 +953,7 @@ impl Resolve<ExecuteArgs> for DestroyStack {
       user,
       |state| state.destroying = true,
       update.clone(),
-      (self.stop_time, self.remove_orphans),
+      (self.stop_time, self.remove_orphans, self.remove_volumes),
     )
     .await
     .map_err(Into::into)

--- a/bin/core/src/stack/execute.rs
+++ b/bin/core/src/stack/execute.rs
@@ -180,12 +180,12 @@ impl ExecuteCompose for StopStack {
 }
 
 impl ExecuteCompose for DestroyStack {
-  type Extras = (Option<i32>, bool);
+  type Extras = (Option<i32>, bool, bool);
   async fn execute(
     periphery: PeripheryClient,
     stack: Stack,
     services: Vec<String>,
-    (timeout, remove_orphans): Self::Extras,
+    (timeout, remove_orphans, remove_volumes): Self::Extras,
   ) -> anyhow::Result<Log> {
     let service_args = service_args(&services);
     let maybe_timeout = maybe_timeout(timeout);
@@ -194,11 +194,16 @@ impl ExecuteCompose for DestroyStack {
     } else {
       ""
     };
+    let maybe_remove_volumes = if remove_volumes {
+      " -v"
+    } else {
+      ""
+    };
     periphery
       .request(ComposeExecution {
         project: stack.project_name(false),
         command: format!(
-          "down{maybe_timeout}{maybe_remove_orphans}{service_args}"
+          "down{maybe_timeout}{maybe_remove_orphans}{maybe_remove_volumes}{service_args}"
         ),
       })
       .await

--- a/client/core/rs/src/api/execute/stack.rs
+++ b/client/core/rs/src/api/execute/stack.rs
@@ -344,6 +344,11 @@ pub struct DestroyStack {
   /// Pass `--remove-orphans`
   #[serde(default)]
   pub remove_orphans: bool,
+  /// Pass `-v` to remove named volumes declared in the compose file
+  /// and anonymous volumes attached to containers.
+  /// Default: false (off for safety - prevents accidental data loss)
+  #[serde(default)]
+  pub remove_volumes: bool,
   /// Override the default termination max time.
   pub stop_time: Option<i32>,
 }


### PR DESCRIPTION
## Summary

Adds a new \emove_volumes\ option to the \DestroyStack\ command that passes the \-v\ flag to \docker compose down\ when enabled.

## Changes

- Added \emove_volumes: bool\ field to \DestroyStack\ struct in the client API
- Updated \ExecuteCompose\ trait implementation for \DestroyStack\ to append \-v\ flag when enabled
- Updated \BatchDestroyStack\ to include the new field with default value

## Behavior

When \emove_volumes\ is set to \	rue\, the destroy command will pass \-v\ to \docker compose down\, which:
- Removes named volumes declared in the \olumes\ section of the Compose file
- Removes anonymous volumes attached to containers

**Default: \alse\** - This is intentionally off by default for safety to prevent accidental data loss, as requested in the issue.

## Related Issue

Closes #1055