### PR TITLE
fix: improve ANSI color contrast in dark mode logs

### DIFF
--- a/frontend/src/components/log.tsx
+++ b/frontend/src/components/log.tsx
@@ -23,6 +23,7 @@ import { Input } from "@ui/input";
 import { ToggleGroup, ToggleGroupItem } from "@ui/toggle-group";
 import { useToast } from "@ui/use-toast";
 import { useLocalStorage } from "@lib/hooks";
+import { useTheme } from "@ui/theme";
 
 export type LogStream = "stdout" | "stderr";
 
@@ -179,6 +180,7 @@ export const Log = ({
   log: Types.Log | undefined;
   stream: "stdout" | "stderr";
 }) => {
+  const { currentTheme } = useTheme();
   const _log = log?.[stream as keyof typeof log] as string | undefined;
   const ref = useRef<HTMLDivElement>(null);
   const scroll = () =>
@@ -192,7 +194,7 @@ export const Log = ({
       <div ref={ref} className="h-[75vh] overflow-y-auto">
         <pre
           dangerouslySetInnerHTML={{
-            __html: _log ? logToHtml(_log) : `no ${stream} logs`,
+            __html: _log ? logToHtml(_log, currentTheme) : `no ${stream} logs`,
           }}
           className="-scroll-mt-24 pb-[20vh]"
         />

--- a/frontend/src/components/resources/action/index.tsx
+++ b/frontend/src/components/resources/action/index.tsx
@@ -15,6 +15,7 @@ import { DashboardPieChart } from "@pages/home/dashboard";
 import { GroupActions } from "@components/group-actions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/tooltip";
 import { Card } from "@ui/card";
+import { useTheme } from "@ui/theme";
 
 const useAction = (id?: string) =>
   useRead("ListActions", {}).data?.find((d) => d.id === id);
@@ -91,6 +92,7 @@ export const ActionComponents: RequiredResourceComponents = {
       );
     },
     ScheduleErrors: ({ id }) => {
+      const { currentTheme } = useTheme();
       const error = useAction(id)?.info.schedule_error;
       if (!error) {
         return null;
@@ -107,7 +109,7 @@ export const ActionComponents: RequiredResourceComponents = {
           <TooltipContent className="w-[400px]">
             <pre
               dangerouslySetInnerHTML={{
-                __html: updateLogToHtml(error),
+                __html: updateLogToHtml(error, currentTheme),
               }}
               className="max-h-[500px] overflow-y-auto"
             />

--- a/frontend/src/components/resources/action/info.tsx
+++ b/frontend/src/components/resources/action/info.tsx
@@ -3,8 +3,10 @@ import { Card, CardContent, CardHeader } from "@ui/card";
 import { cn, getUpdateQuery, updateLogToHtml } from "@lib/utils";
 import { useRead } from "@lib/hooks";
 import { text_color_class_by_intention } from "@lib/color";
+import { useTheme } from "@ui/theme";
 
 export const ActionInfo = ({ id }: { id: string }) => {
+  const { currentTheme } = useTheme();
   const update = useRead("ListUpdates", {
     query: {
       ...getUpdateQuery({ type: "Action", id }, undefined),
@@ -49,7 +51,7 @@ export const ActionInfo = ({ id }: { id: string }) => {
           <CardContent className="pr-8">
             <pre
               dangerouslySetInnerHTML={{
-                __html: updateLogToHtml(log.stdout),
+                __html: updateLogToHtml(log.stdout, currentTheme),
               }}
               className="max-h-[500px] overflow-y-auto"
             />
@@ -67,7 +69,7 @@ export const ActionInfo = ({ id }: { id: string }) => {
           <CardContent className="pr-8">
             <pre
               dangerouslySetInnerHTML={{
-                __html: updateLogToHtml(log.stderr),
+                __html: updateLogToHtml(log.stderr, currentTheme),
               }}
               className="max-h-[500px] overflow-y-auto"
             />

--- a/frontend/src/components/resources/build/info.tsx
+++ b/frontend/src/components/resources/build/info.tsx
@@ -19,6 +19,7 @@ import { useToast } from "@ui/use-toast";
 import { ConfirmButton, ShowHideButton } from "@components/util";
 import { DEFAULT_BUILD_DOCKERFILE_CONTENTS } from "./config";
 import { fmt_duration } from "@lib/formatting";
+import { useTheme } from "@ui/theme";
 
 export const BuildInfo = ({
   id,
@@ -27,6 +28,7 @@ export const BuildInfo = ({
   id: string;
   titleOther: ReactNode;
 }) => {
+  const { currentTheme } = useTheme();
   const [edits, setEdits] = useLocalStorage<{ contents: string | undefined }>(
     `build-${id}-edits`,
     { contents: undefined }
@@ -99,7 +101,7 @@ export const BuildInfo = ({
           <CardContent className="pr-8">
             <pre
               dangerouslySetInnerHTML={{
-                __html: updateLogToHtml(remote_error),
+                __html: updateLogToHtml(remote_error, currentTheme),
               }}
               className="max-h-[500px] overflow-y-auto"
             />
@@ -202,7 +204,7 @@ export const BuildInfo = ({
                   <CardDescription>stdout</CardDescription>
                   <pre
                     dangerouslySetInnerHTML={{
-                      __html: updateLogToHtml(log.stdout),
+                      __html: updateLogToHtml(log.stdout, currentTheme),
                     }}
                     className="max-h-[500px] overflow-y-auto"
                   />
@@ -213,7 +215,7 @@ export const BuildInfo = ({
                   <CardDescription>stderr</CardDescription>
                   <pre
                     dangerouslySetInnerHTML={{
-                      __html: updateLogToHtml(log.stderr),
+                      __html: updateLogToHtml(log.stderr, currentTheme),
                     }}
                     className="max-h-[500px] overflow-y-auto"
                   />

--- a/frontend/src/components/resources/procedure/index.tsx
+++ b/frontend/src/components/resources/procedure/index.tsx
@@ -15,6 +15,7 @@ import { DashboardPieChart } from "@pages/home/dashboard";
 import { GroupActions } from "@components/group-actions";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/tooltip";
 import { Card } from "@ui/card";
+import { useTheme } from "@ui/theme";
 
 const useProcedure = (id?: string) =>
   useRead("ListProcedures", {}).data?.find((d) => d.id === id);
@@ -97,6 +98,7 @@ export const ProcedureComponents: RequiredResourceComponents = {
       );
     },
     ScheduleErrors: ({ id }) => {
+      const { currentTheme } = useTheme();
       const error = useProcedure(id)?.info.schedule_error;
       if (!error) {
         return null;
@@ -113,7 +115,7 @@ export const ProcedureComponents: RequiredResourceComponents = {
           <TooltipContent className="w-[400px]">
             <pre
               dangerouslySetInnerHTML={{
-                __html: updateLogToHtml(error),
+                __html: updateLogToHtml(error, currentTheme),
               }}
               className="max-h-[500px] overflow-y-auto"
             />

--- a/frontend/src/components/resources/resource-sync/info.tsx
+++ b/frontend/src/components/resources/resource-sync/info.tsx
@@ -11,6 +11,7 @@ import { Button } from "@ui/button";
 import { FilePlus, History } from "lucide-react";
 import { ConfirmUpdate } from "@components/config/util";
 import { ConfirmButton, ShowHideButton } from "@components/util";
+import { useTheme } from "@ui/theme";
 
 export const ResourceSyncInfo = ({
   id,
@@ -19,6 +20,7 @@ export const ResourceSyncInfo = ({
   id: string;
   titleOther: ReactNode;
 }) => {
+  const { currentTheme } = useTheme();
   const [edits, setEdits] = useLocalStorage<Record<string, string | undefined>>(
     `sync-${id}-edits`,
     {}
@@ -93,7 +95,7 @@ export const ResourceSyncInfo = ({
             <CardContent className="pr-8">
               <pre
                 dangerouslySetInnerHTML={{
-                  __html: updateLogToHtml(error.contents),
+                  __html: updateLogToHtml(error.contents, currentTheme),
                 }}
                 className="max-h-[500px] overflow-y-auto"
               />

--- a/frontend/src/components/resources/stack/info.tsx
+++ b/frontend/src/components/resources/stack/info.tsx
@@ -19,6 +19,7 @@ import { useToast } from "@ui/use-toast";
 import { ConfirmButton, ShowHideButton, CopyButton } from "@components/util";
 import { DEFAULT_STACK_FILE_CONTENTS } from "./config";
 import { Types } from "komodo_client";
+import { useTheme } from "@ui/theme";
 
 export const StackInfo = ({
   id,
@@ -27,6 +28,7 @@ export const StackInfo = ({
   id: string;
   titleOther: ReactNode;
 }) => {
+  const { currentTheme } = useTheme();
   const [edits, setEdits] = useLocalStorage<Record<string, string | undefined>>(
     `stack-${id}-edits`,
     {}
@@ -119,7 +121,7 @@ export const StackInfo = ({
             <CardContent className="pr-8">
               <pre
                 dangerouslySetInnerHTML={{
-                  __html: updateLogToHtml(error.contents),
+                  __html: updateLogToHtml(error.contents, currentTheme),
                 }}
                 className="max-h-[500px] overflow-y-auto"
               />

--- a/frontend/src/components/updates/details.tsx
+++ b/frontend/src/components/updates/details.tsx
@@ -38,6 +38,7 @@ import { CopyButton, UserAvatar } from "@components/util";
 import { ResourceNameSimple } from "@components/resources/common";
 import { useWebsocketMessages } from "@lib/socket";
 import { MonacoDiffEditor } from "@components/monaco";
+import { useTheme } from "@ui/theme";
 
 export const UpdateUser = ({
   user_id,
@@ -124,6 +125,7 @@ export const UpdateDetailsContent = ({
   open?: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
+  const { currentTheme } = useTheme();
   const { data: update, refetch } = useRead(
     "GetUpdate",
     { id },
@@ -255,7 +257,7 @@ export const UpdateDetailsContent = ({
                   <CardDescription>stdout</CardDescription>
                   <pre
                     dangerouslySetInnerHTML={{
-                      __html: updateLogToHtml(log.stdout),
+                      __html: updateLogToHtml(log.stdout, currentTheme),
                     }}
                     className="max-h-[500px] overflow-y-auto"
                   />
@@ -266,7 +268,7 @@ export const UpdateDetailsContent = ({
                   <CardDescription>stderr</CardDescription>
                   <pre
                     dangerouslySetInnerHTML={{
-                      __html: updateLogToHtml(log.stderr),
+                      __html: updateLogToHtml(log.stderr, currentTheme),
                     }}
                     className="max-h-[500px] overflow-y-auto"
                   />

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -165,23 +165,51 @@ export const sanitizeOnlySpan = (log: string) => {
   });
 };
 
+// Dark mode ANSI color palette with improved contrast
+// Based on GitHub's dark mode terminal colors for excellent readability
+const darkModeColors: Record<number, string> = {
+  0: "#6E7681", // Black -> visible gray
+  1: "#FF7B72", // Red -> bright red
+  2: "#7EE787", // Green -> bright green
+  3: "#FFA657", // Yellow -> bright orange
+  4: "#79C0FF", // Blue -> bright blue (key fix for issue #1049)
+  5: "#D2A8FF", // Magenta -> light purple
+  6: "#56D4DD", // Cyan -> bright cyan
+  7: "#FFFFFF", // White
+  8: "#8B949E", // Bright Black -> medium gray
+  9: "#FF7B72", // Bright Red
+  10: "#7EE787", // Bright Green
+  11: "#FFA657", // Bright Yellow
+  12: "#79C0FF", // Bright Blue
+  13: "#D2A8FF", // Bright Magenta
+  14: "#56D4DD", // Bright Cyan
+  15: "#FFFFFF", // Bright White
+};
+
+const convertLight = new Convert();
+const convertDark = new Convert({ colors: darkModeColors });
+
+export type ThemeMode = "light" | "dark";
+
 /**
  * Converts the ansi colors in an Update log to html.
  * sanitizes incoming log first for any eg. script tags.
  * @param log incoming log string
+ * @param theme current theme mode (defaults to light for backwards compatibility)
  */
-export const updateLogToHtml = (log: string) => {
+export const updateLogToHtml = (log: string, theme: ThemeMode = "light") => {
   if (!log) return "No log.";
+  const convert = theme === "dark" ? convertDark : convertLight;
   return convert.toHtml(sanitizeOnlySpan(log));
 };
 
-const convert = new Convert();
 /**
  * Converts the ansi colors in log to html.
  * sanitizes incoming log first for any eg. script tags.
  * @param log incoming log string
+ * @param theme current theme mode (defaults to light for backwards compatibility)
  */
-export const logToHtml = (log: string) => {
+export const logToHtml = (log: string, theme: ThemeMode = "light") => {
   if (!log) return "No log.";
   const sanitized = sanitizeHtml(log, {
     allowedTags: sanitizeHtml.defaults.allowedTags.filter(
@@ -189,6 +217,7 @@ export const logToHtml = (log: string) => {
     ),
     allowedAttributes: sanitizeHtml.defaults.allowedAttributes,
   });
+  const convert = theme === "dark" ? convertDark : convertLight;
   return convert.toHtml(sanitized);
 };
 


### PR DESCRIPTION
## Summary

Fixes #1049 - Dark mode makes colored logs unreadable

## Problem

Dark blue ANSI text (#0000AA) was invisible against dark mode backgrounds, making logs with colored output (like Docker build logs, npm logs, etc.) unreadable.

## Solution

Added a theme-aware ANSI color palette that automatically adjusts colors based on the current theme:

- **Light mode**: Uses the default ANSI colors (unchanged behavior)
- **Dark mode**: Uses a custom high-contrast palette based on GitHub's dark mode terminal colors

### Key color changes in dark mode:
| Color | Original | Dark Mode |
|-------|----------|-----------|
| Blue | #0000AA | #79C0FF |
| Red | #AA0000 | #FF7B72 |
| Green | #00AA00 | #7EE787 |
| Yellow | #AA5500 | #FFA657 |
| Magenta | #AA00AA | #D2A8FF |
| Cyan | #00AAAA | #56D4DD |
| Black | #000000 | #6E7681 |

### Changes:
- Modified \rontend/src/lib/utils.ts\:
  - Added \darkModeColors\ palette for ANSI colors 0-15
  - Created separate converters for light and dark modes
  - Updated \logToHtml\ and \updateLogToHtml\ to accept optional theme parameter

- Updated all components that display logs:
  - \log.tsx\
  - \ction/index.tsx\, \ction/info.tsx\
  - \uild/info.tsx\
  - \procedure/index.tsx\
  - \esource-sync/info.tsx\
  - \stack/info.tsx\
  - \updates/details.tsx\

## Testing

- Verified all updated components use the theme-aware color conversion
- Backwards compatible: defaults to light mode colors when theme is not specified