### PR TITLE
fix: improve font-family fallbacks for Firefox compatibility

### DIFF
--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -15,8 +15,8 @@
 
   body {
     @apply bg-background text-foreground;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-      "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+      Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans",
       "Helvetica Neue", sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Summary
Fixes the font rendering inconsistency between Firefox and Chrome/Safari reported in #1006.

## Problem
The UI font appeared different (less clean) in Firefox compared to Chrome. This was because the font-family declaration started with \-apple-system\ and \BlinkMacSystemFont\, which are vendor-specific keywords that Firefox doesn't recognize.

## Solution
Added \system-ui\ as the primary font-family value. This is the W3C standard keyword for the operating system's default UI font, supported by:
- Firefox 67+
- Chrome 56+
- Safari 11+
- Edge 79+

The browser-specific fallbacks (\-apple-system\, \BlinkMacSystemFont\) are preserved for older browsers.

## Testing
Verified that the font stack properly falls back to \system-ui\ in Firefox, providing consistent rendering with other browsers.

Closes #1006