### PR TITLE
fix: prevent custom registry org input from deselecting

### DIFF
--- a/frontend/src/components/resources/build/config.tsx
+++ b/frontend/src/components/resources/build/config.tsx
@@ -266,12 +266,7 @@ export const BuildConfig = ({
 
             {image_registries?.map((registry, index) => (
               <ImageRegistryConfig
-                key={
-                  (registry.domain ?? "") +
-                  (registry.organization ?? "") +
-                  (registry.account ?? "") +
-                  index
-                }
+                key={index}
                 registry={registry}
                 imageName={imageName}
                 setRegistry={(registry) =>


### PR DESCRIPTION
## Summary

Fixes the bug where typing in the 'Custom' organization name field in the Build Config's Image Registry section would deselect after entering a single character.

## Root Cause

The \ImageRegistryConfig\ component's React key included \egistry.organization\:

\\\jsx
key={
  (registry.domain ?? '') +
  (registry.organization ?? '') +  // This changes on every keystroke!
  (registry.account ?? '') +
  index
}
\\\

When the user types a character in the custom organization input, the organization value changes, which changes the key. React interprets this as a new component and unmounts/remounts it, destroying the \OrganizationSelector\'s internal \customMode\ state and switching back to the dropdown view.

## Fix

Use a stable \index\-based key that doesn't change when the registry data is edited:

\\\jsx
key={index}
\\\

This preserves component identity during edits while still allowing React to efficiently reconcile the list.

Closes #1094