### PR TITLE
fix: properly escape special characters in registry passwords

### DIFF
--- a/bin/periphery/src/docker/mod.rs
+++ b/bin/periphery/src/docker/mod.rs
@@ -1,10 +1,11 @@
-use std::sync::OnceLock;
+use std::{borrow::Cow, sync::OnceLock};
 
 use anyhow::anyhow;
 use bollard::Docker;
 use command::run_komodo_command;
 use komodo_client::entities::{TerminationSignal, update::Log};
 use run_command::async_run_command;
+use shell_escape::unix::escape;
 
 pub mod stats;
 
@@ -46,8 +47,10 @@ pub async fn docker_login(
     Some(token) => token,
     None => crate::helpers::registry_token(domain, account)?,
   };
+  // Escape special shell characters in the token (fixes issues with '(', "'", etc.)
+  let escaped_token = escape(Cow::Borrowed(registry_token));
   let log = async_run_command(&format!(
-    "echo {registry_token} | docker login {domain} --username '{account}' --password-stdin",
+    "echo {escaped_token} | docker login {domain} --username '{account}' --password-stdin",
   ))
   .await;
   if log.success() {


### PR DESCRIPTION
## Summary

Fixes #1090

Registry authentication fails when passwords contain shell special characters like `(` or single quotes (`'`). The error manifests as:

```
sh: 1: Syntax error: "(" unexpected
```
or
```
sh: 1: Syntax error: Unterminated quoted string
```

## Root Cause

The `docker_login` function in `bin/periphery/src/docker/mod.rs` passes the registry token directly to a shell command without proper escaping:

```rust
echo {registry_token} | docker login ... --password-stdin
```

When the token contains shell metacharacters, the shell interprets them instead of treating them as literal characters.

## Fix

Use the existing `shell_escape` crate (already a dependency) to properly escape the token before passing it to the shell:

```rust
let escaped_token = escape(Cow::Borrowed(registry_token));
```

This follows the same pattern already used elsewhere in the codebase (e.g., `compose.rs`).
