### PR TITLE
fix: exclude templates from stack summary counts

### DIFF
--- a/bin/core/src/api/read/stack.rs
+++ b/bin/core/src/api/read/stack.rs
@@ -357,6 +357,12 @@ impl Resolve<ReadArgs> for GetStacksSummary {
     let cache = stack_status_cache();
 
     for stack in stacks {
+      // Count templates separately; don't include in other stats
+      if stack.template {
+        res.templates += 1;
+        continue;
+      }
+
       res.total += 1;
       match cache.get(&stack.id).await.unwrap_or_default().curr.state
       {

--- a/client/core/rs/src/api/read/stack.rs
+++ b/client/core/rs/src/api/read/stack.rs
@@ -263,7 +263,7 @@ pub struct GetStacksSummary {}
 #[typeshare]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GetStacksSummaryResponse {
-  /// The total number of stacks
+  /// The total number of stacks (excluding templates)
   pub total: u32,
   /// The number of stacks with Running state.
   pub running: u32,
@@ -275,6 +275,9 @@ pub struct GetStacksSummaryResponse {
   pub unhealthy: u32,
   /// The number of stacks with Unknown state.
   pub unknown: u32,
+  /// The number of stacks marked as templates.
+  #[serde(default)]
+  pub templates: u32,
 }
 
 //


### PR DESCRIPTION
## Summary

Fixes #998

The `GetStacksSummary` API endpoint was counting templates as part of the total and marking them as "down", making it difficult to identify genuine issues.

## Changes

1. Added a new `templates` field to `GetStacksSummaryResponse` to track the count of template stacks
2. Templates are now excluded from `total`, `running`, `stopped`, `down`, `unhealthy`, and `unknown` counts

## API Response

Before:
```json
{"total":18,"running":17,"stopped":0,"down":1,"unhealthy":0,"unknown":0}
```

After:
```json
{"total":17,"running":17,"stopped":0,"down":0,"unhealthy":0,"unknown":0,"templates":1}
```

## Backward Compatibility

The new `templates` field uses `#[serde(default)]` so existing clients that don't expect this field will continue to work (it will deserialize as 0 if missing).
