### PR TITLE
fix: disable buttons and show loading state during operations

### DIFF
--- a/frontend/src/components/config/util.tsx
+++ b/frontend/src/components/config/util.tsx
@@ -299,17 +299,26 @@ export function ConfirmUpdate<T>({
   previous,
   content,
   onConfirm,
-  loading,
+  loading: externalLoading,
   disabled,
   language,
   file_contents_language,
   key_listener = false,
 }: ConfirmUpdateProps<T>) {
   const [open, set] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Combine external loading prop with internal loading state
+  const loading = externalLoading || isLoading;
 
   const handleConfirm = async () => {
-    await onConfirm();
-    set(false);
+    setIsLoading(true);
+    try {
+      await onConfirm();
+      set(false);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleCancel = () => {
@@ -319,6 +328,7 @@ export function ConfirmUpdate<T>({
   // Keep the existing Ctrl+Enter behavior for backward compatibility
   useCtrlKeyListener("Enter", () => {
     if (!key_listener) return;
+    if (loading) return;
     if (open) {
       handleConfirm();
     } else {
@@ -335,7 +345,7 @@ export function ConfirmUpdate<T>({
   });
 
   return (
-    <Dialog open={open} onOpenChange={set}>
+    <Dialog open={open} onOpenChange={(value) => !loading && set(value)}>
       <DialogTrigger asChild>
         <Button
           onClick={() => set(true)}
@@ -368,6 +378,7 @@ export function ConfirmUpdate<T>({
             icon={<CheckCircle className="w-4 h-4" />}
             onClick={handleConfirm}
             loading={loading}
+            disabled={disabled || loading}
           />
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary

Fixes #1045 - The update buttons now properly show loading/disabled state during operations.

## Problem

When making changes to resources (like stacks), the update button would remain in its normal state while the operation was in progress. This was confusing for users who couldn't tell if their action was being processed.

## Solution

Modified the \ConfirmUpdate\ component to manage its own loading state internally. The changes include:

- **Added internal loading state tracking**: When \onConfirm\ is called, the component sets \isLoading\ to true, waits for the async operation, then sets it back to false
- **Combined loading states**: The external \loading\ prop is combined with the internal state, allowing both explicit loading props and automatic tracking
- **Prevented premature dialog closure**: The dialog cannot be closed while an operation is in progress
- **Blocked duplicate submissions**: Ctrl+Enter keyboard shortcut is disabled during loading
- **Visual feedback**: The confirm button shows a loading spinner and is disabled during operations

## Testing

- Verified the button shows a loading spinner during async operations
- Confirmed the dialog stays open until the operation completes
- Tested that clicking the button multiple times doesn't trigger duplicate operations

## Screenshots

The button now shows a loading spinner while the operation is in progress, providing clear feedback to users.