### PR TITLE
fix: handle IPv6 addresses in container port links

### DIFF
--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -1245,9 +1245,12 @@ export const ContainerPortLink = ({
   if (!server_address) return null;
 
   const isHttps = server_address.protocol === "https:";
+  const host = server_address.hostname.includes(":")
+    ? `[${server_address.hostname}]`
+    : server_address.hostname;
   const link = host_port === "443" && isHttps
-    ? `https://${server_address.hostname}`
-    : `http://${server_address.hostname}:${host_port}`;
+    ? `https://${host}`
+    : `http://${host}:${host_port}`;
 
   const uniqueHostPorts = Array.from(
     new Set(


### PR DESCRIPTION
Fix IPv6 addresses in container port links. When a container exposes ports on an IPv6 address (e.g. [::]:8080), the link generated in the UI was malformed. This fix properly handles IPv6 address formatting in port links.

Closes #633