### PR TITLE
fix: clear DataTable stale checkbox state after group delete

### DIFF
--- a/frontend/src/components/resources/action/table.tsx
+++ b/frontend/src/components/resources/action/table.tsx
@@ -10,7 +10,7 @@ export const ActionTable = ({
 }: {
   actions: Types.ActionListItem[];
 }) => {
-  const [_, setSelectedResources] = useSelectedResources("Action");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Action");
 
   return (
     <DataTable
@@ -18,6 +18,7 @@ export const ActionTable = ({
       data={actions}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/alerter/table.tsx
+++ b/frontend/src/components/resources/alerter/table.tsx
@@ -9,13 +9,14 @@ export const AlerterTable = ({
 }: {
   alerters: Types.AlerterListItem[];
 }) => {
-  const [_, setSelectedResources] = useSelectedResources("Alerter");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Alerter");
   return (
     <DataTable
       tableKey="alerters"
       data={alerters}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/build/table.tsx
+++ b/frontend/src/components/resources/build/table.tsx
@@ -7,7 +7,7 @@ import { Types } from "komodo_client";
 import { useSelectedResources } from "@lib/hooks";
 
 export const BuildTable = ({ builds }: { builds: Types.BuildListItem[] }) => {
-  const [_, setSelectedResources] = useSelectedResources("Build");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Build");
 
   return (
     <DataTable
@@ -15,6 +15,7 @@ export const BuildTable = ({ builds }: { builds: Types.BuildListItem[] }) => {
       data={builds}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/builder/table.tsx
+++ b/frontend/src/components/resources/builder/table.tsx
@@ -10,13 +10,14 @@ export const BuilderTable = ({
 }: {
   builders: Types.BuilderListItem[];
 }) => {
-  const [_, setSelectedResources] = useSelectedResources("Builder");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Builder");
   return (
     <DataTable
       tableKey="builders"
       data={builders}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/deployment/table.tsx
+++ b/frontend/src/components/resources/deployment/table.tsx
@@ -18,7 +18,7 @@ export const DeploymentTable = ({
     [servers]
   );
 
-  const [_, setSelectedResources] = useSelectedResources("Deployment");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Deployment");
 
   return (
     <DataTable
@@ -26,6 +26,7 @@ export const DeploymentTable = ({
       data={deployments}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/procedure/table.tsx
+++ b/frontend/src/components/resources/procedure/table.tsx
@@ -10,7 +10,7 @@ export const ProcedureTable = ({
 }: {
   procedures: Types.ProcedureListItem[];
 }) => {
-  const [_, setSelectedResources] = useSelectedResources("Procedure");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Procedure");
 
   return (
     <DataTable
@@ -18,6 +18,7 @@ export const ProcedureTable = ({
       data={procedures}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/repo/table.tsx
+++ b/frontend/src/components/resources/repo/table.tsx
@@ -7,7 +7,7 @@ import { useSelectedResources } from "@lib/hooks";
 import { RepoLink } from "@components/util";
 
 export const RepoTable = ({ repos }: { repos: Types.RepoListItem[] }) => {
-  const [_, setSelectedResources] = useSelectedResources("Repo");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Repo");
 
   return (
     <DataTable
@@ -15,6 +15,7 @@ export const RepoTable = ({ repos }: { repos: Types.RepoListItem[] }) => {
       data={repos}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/resource-sync/table.tsx
+++ b/frontend/src/components/resources/resource-sync/table.tsx
@@ -10,13 +10,14 @@ export const ResourceSyncTable = ({
 }: {
   syncs: Types.ResourceSyncListItem[];
 }) => {
-  const [_, setSelectedResources] = useSelectedResources("ResourceSync");
+  const [selectedResources, setSelectedResources] = useSelectedResources("ResourceSync");
   return (
     <DataTable
       tableKey="syncs"
       data={syncs}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/server/table.tsx
+++ b/frontend/src/components/resources/server/table.tsx
@@ -11,7 +11,7 @@ export const ServerTable = ({
 }: {
   servers: Types.ServerListItem[];
 }) => {
-  const [_, setSelectedResources] = useSelectedResources("Server");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Server");
   const deployments = useRead("ListDeployments", {}).data;
   const stacks = useRead("ListStacks", {}).data;
   const repos = useRead("ListRepos", {}).data;
@@ -31,6 +31,7 @@ export const ServerTable = ({
       data={servers}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/components/resources/stack/table.tsx
+++ b/frontend/src/components/resources/stack/table.tsx
@@ -13,7 +13,7 @@ export const StackTable = ({ stacks }: { stacks: Types.StackListItem[] }) => {
     [servers]
   );
 
-  const [_, setSelectedResources] = useSelectedResources("Stack");
+  const [selectedResources, setSelectedResources] = useSelectedResources("Stack");
 
   return (
     <DataTable
@@ -21,6 +21,7 @@ export const StackTable = ({ stacks }: { stacks: Types.StackListItem[] }) => {
       data={stacks}
       selectOptions={{
         selectKey: ({ name }) => name,
+        selected: selectedResources,
         onSelect: setSelectedResources,
       }}
       columns={[

--- a/frontend/src/ui/data-table.tsx
+++ b/frontend/src/ui/data-table.tsx
@@ -34,6 +34,7 @@ interface DataTableProps<TData, TValue> {
   sortDescFirst?: boolean;
   selectOptions?: {
     selectKey: (row: TData) => string;
+    selected?: string[];
     onSelect: (selected: string[]) => void;
     disableRow?: boolean | ((row: Row<TData>) => boolean);
   };
@@ -86,6 +87,15 @@ export function DataTable<TData, TValue>({
   useEffect(() => {
     selectOptions?.onSelect(Object.keys(rowSelection));
   }, [rowSelection]);
+
+  // Sync external selection clears (e.g. after group delete) back to internal state
+  const selectedLength = selectOptions?.selected?.length ?? -1;
+  useEffect(() => {
+    if (selectedLength === -1) return;
+    if (selectedLength === 0 && Object.keys(rowSelection).length > 0) {
+      setRowSelection({});
+    }
+  }, [selectedLength]);
 
   return (
     <div


### PR DESCRIPTION
Fix stale checkbox state in DataTable after a group delete operation. The action list was not being cleared after deletion, leaving orphaned checkbox selections that could cause confusion or errors.

Closes #396