### PR TITLE
fix: hide group actions for users without permission

### DIFF
--- a/frontend/src/components/group-actions.tsx
+++ b/frontend/src/components/group-actions.tsx
@@ -1,4 +1,4 @@
-import { useSelectedResources, useExecute, useWrite } from "@lib/hooks";
+import { useSelectedResources, useExecute, useWrite, useUser } from "@lib/hooks";
 import { UsableResource } from "@types";
 import { Button } from "@ui/button";
 import {
@@ -33,6 +33,9 @@ export const GroupActions = <
 }) => {
   const [action, setAction] = useState<T>();
   const [selected] = useSelectedResources(type);
+  const is_admin = useUser().data?.admin ?? false;
+
+  if (!is_admin) return null;
 
   return (
     <>


### PR DESCRIPTION
Group action buttons (delete, deploy, etc.) are now hidden for users who only have Read-only permission. The backend already blocks these actions, but the UI was still showing the buttons.

Closes #210