### PR TITLE
fix: escape special characters in deployment labels

### DIFF
--- a/bin/periphery/src/helpers.rs
+++ b/bin/periphery/src/helpers.rs
@@ -67,7 +67,11 @@ pub fn parse_labels(labels: &[EnvironmentVar]) -> String {
         // If the value already wrapped in quotes, don't wrap it again
         format!(" --label {}={}", p.variable, p.value)
       } else {
-        format!(" --label {}=\"{}\"", p.variable, p.value)
+        // Use single quotes to prevent shell interpretation of special
+        // characters (backticks, angle brackets, $, etc.).
+        // Escape any single quotes within the value.
+        let escaped = p.value.replace('\'', "'\\''");
+        format!(" --label {}='{}'", p.variable, escaped)
       }
     })
     .collect::<Vec<_>>()


### PR DESCRIPTION
Deployment labels containing special characters (backticks, angle brackets, etc.) are now properly escaped when building Docker commands. This fixes issues with Traefik routing rules and similar labels.

The fix changes `parse_labels` in `bin/periphery/src/helpers.rs` to use single quotes instead of double quotes for label values. Single quotes prevent shell interpretation of special characters like backticks, angle brackets, and dollar signs. Any single quotes within label values are properly escaped using the standard `'\''` shell idiom.

Closes #476