### PR TITLE
fix: always serialize empty params in procedure export

### DIFF
--- a/bin/core/src/sync/toml.rs
+++ b/bin/core/src/sync/toml.rs
@@ -849,7 +849,11 @@ impl ToToml for Procedure {
             stage,
             // If the execution.params are fully missing,
             // deserialization will fail.
-            TOML_PRETTY_OPTIONS.skip_empty_object(false),
+            // Also keep empty strings (eg pattern = "") so that
+            // all required fields are present in the output.
+            TOML_PRETTY_OPTIONS
+              .skip_empty_object(false)
+              .skip_empty_string(false),
           )
           .context("failed to serialize procedures to toml")?,
         );

--- a/client/core/rs/src/api/execute/action.rs
+++ b/client/core/rs/src/api/execute/action.rs
@@ -66,5 +66,6 @@ pub struct BatchRunAction {
   /// # add some more
   /// extra-action-1, extra-action-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }

--- a/client/core/rs/src/api/execute/build.rs
+++ b/client/core/rs/src/api/execute/build.rs
@@ -70,6 +70,7 @@ pub struct BatchRunBuild {
   /// # add some more
   /// extra-build-1, extra-build-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }
 

--- a/client/core/rs/src/api/execute/deployment.rs
+++ b/client/core/rs/src/api/execute/deployment.rs
@@ -68,6 +68,7 @@ pub struct BatchDeploy {
   /// # add some more
   /// extra-deployment-1, extra-deployment-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }
 
@@ -276,5 +277,6 @@ pub struct BatchDestroyDeployment {
   /// # add some more
   /// extra-deployment-1, extra-deployment-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }

--- a/client/core/rs/src/api/execute/procedure.rs
+++ b/client/core/rs/src/api/execute/procedure.rs
@@ -54,5 +54,6 @@ pub struct BatchRunProcedure {
   /// # add some more
   /// extra-procedure-1, extra-procedure-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }

--- a/client/core/rs/src/api/execute/repo.rs
+++ b/client/core/rs/src/api/execute/repo.rs
@@ -66,6 +66,7 @@ pub struct BatchCloneRepo {
   /// # add some more
   /// extra-repo-1, extra-repo-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }
 
@@ -124,6 +125,7 @@ pub struct BatchPullRepo {
   /// # add some more
   /// extra-repo-1, extra-repo-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }
 
@@ -186,6 +188,7 @@ pub struct BatchBuildRepo {
   /// # add some more
   /// extra-repo-1, extra-repo-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }
 

--- a/client/core/rs/src/api/execute/stack.rs
+++ b/client/core/rs/src/api/execute/stack.rs
@@ -65,6 +65,7 @@ pub struct BatchDeployStack {
   /// # add some more
   /// extra-stack-1, extra-stack-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }
 
@@ -123,6 +124,7 @@ pub struct BatchDeployStackIfChanged {
   /// # add some more
   /// extra-stack-1, extra-stack-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }
 
@@ -180,6 +182,7 @@ pub struct BatchPullStack {
   /// # add some more
   /// extra-stack-1, extra-stack-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }
 
@@ -434,5 +437,6 @@ pub struct BatchDestroyStack {
   /// # add some more
   /// extra-stack-1, extra-stack-2
   /// ```
+  #[serde(default)]
   pub pattern: String,
 }


### PR DESCRIPTION
When serializing procedure stages to TOML, empty string fields (like `pattern`) were dropped by toml_pretty's `skip_empty_string` option. This caused params to be empty/missing, failing deserialization with `missing field params`.

Two fixes:
1. Disable `skip_empty_string` when serializing procedure stages so fields like `pattern = ""` are preserved in TOML output.
2. Add `#[serde(default)]` to `pattern` fields on all Batch* execution structs as defense-in-depth.

Closes #672