### PR TITLE
feat: add shallow clone option for git repos (--depth 1)

### DIFF
--- a/client/core/rs/src/entities/build.rs
+++ b/client/core/rs/src/entities/build.rs
@@ -361,6 +361,12 @@ pub struct BuildConfig {
   #[builder(default)]
   pub commit: String,
 
+  /// Use shallow clone (--depth 1) to speed up cloning large repos.
+  /// Only the latest history on the specified branch will be fetched.
+  #[serde(default)]
+  #[builder(default)]
+  pub shallow_clone: bool,
+
   /// Whether incoming webhooks actually trigger action.
   #[serde(default = "default_webhook_enabled")]
   #[builder(default = "default_webhook_enabled()")]
@@ -530,6 +536,7 @@ impl Default for BuildConfig {
       repo: Default::default(),
       branch: default_branch(),
       commit: Default::default(),
+      shallow_clone: Default::default(),
       git_account: Default::default(),
       pre_build: Default::default(),
       build_path: default_build_path(),

--- a/client/core/rs/src/entities/mod.rs
+++ b/client/core/rs/src/entities/mod.rs
@@ -444,6 +444,8 @@ pub struct RepoExecutionArgs {
   /// The default folder to use.
   /// Depends on the resource type.
   pub default_folder: DefaultRepoFolder,
+  /// Use shallow clone (--depth 1) to speed up cloning large repos.
+  pub shallow_clone: bool,
 }
 
 impl RepoExecutionArgs {
@@ -519,6 +521,7 @@ impl From<&self::stack::Stack> for RepoExecutionArgs {
       commit: optional_string(&stack.config.commit),
       destination: optional_string(&stack.config.clone_path),
       default_folder: DefaultRepoFolder::Stacks,
+      shallow_clone: stack.config.shallow_clone,
     }
   }
 }
@@ -537,6 +540,7 @@ impl From<&self::build::Build> for RepoExecutionArgs {
       commit: optional_string(&build.config.commit),
       destination: None,
       default_folder: DefaultRepoFolder::Builds,
+      shallow_clone: build.config.shallow_clone,
     }
   }
 }
@@ -555,6 +559,7 @@ impl From<&self::repo::Repo> for RepoExecutionArgs {
       commit: optional_string(&repo.config.commit),
       destination: optional_string(&repo.config.path),
       default_folder: DefaultRepoFolder::Repos,
+      shallow_clone: repo.config.shallow_clone,
     }
   }
 }
@@ -573,6 +578,7 @@ impl From<&self::sync::ResourceSync> for RepoExecutionArgs {
       commit: optional_string(&sync.config.commit),
       destination: None,
       default_folder: DefaultRepoFolder::NotApplicable,
+      shallow_clone: sync.config.shallow_clone,
     }
   }
 }

--- a/client/core/rs/src/entities/repo.rs
+++ b/client/core/rs/src/entities/repo.rs
@@ -164,6 +164,12 @@ pub struct RepoConfig {
   #[builder(default)]
   pub path: String,
 
+  /// Use shallow clone (--depth 1) to speed up cloning large repos.
+  /// Only the latest history on the specified branch will be fetched.
+  #[serde(default)]
+  #[builder(default)]
+  pub shallow_clone: bool,
+
   /// Whether incoming webhooks actually trigger action.
   #[serde(default = "default_webhook_enabled")]
   #[builder(default = "default_webhook_enabled()")]
@@ -267,6 +273,7 @@ impl Default for RepoConfig {
       commit: Default::default(),
       git_account: Default::default(),
       path: Default::default(),
+      shallow_clone: Default::default(),
       on_clone: Default::default(),
       on_pull: Default::default(),
       links: Default::default(),

--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -382,6 +382,12 @@ pub struct StackConfig {
   #[builder(default)]
   pub reclone: bool,
 
+  /// Use shallow clone (--depth 1) to speed up cloning large repos.
+  /// Only the latest history on the specified branch will be fetched.
+  #[serde(default)]
+  #[builder(default)]
+  pub shallow_clone: bool,
+
   /// Whether incoming webhooks actually trigger action.
   #[serde(default = "default_webhook_enabled")]
   #[builder(default = "default_webhook_enabled()")]
@@ -614,6 +620,7 @@ impl Default for StackConfig {
       commit: Default::default(),
       clone_path: Default::default(),
       reclone: Default::default(),
+      shallow_clone: Default::default(),
       git_account: Default::default(),
       webhook_enabled: default_webhook_enabled(),
       webhook_secret: Default::default(),

--- a/client/core/rs/src/entities/sync.rs
+++ b/client/core/rs/src/entities/sync.rs
@@ -217,6 +217,12 @@ pub struct ResourceSyncConfig {
   #[builder(default)]
   pub git_account: String,
 
+  /// Use shallow clone (--depth 1) to speed up cloning large repos.
+  /// Only the latest history on the specified branch will be fetched.
+  #[serde(default)]
+  #[builder(default)]
+  pub shallow_clone: bool,
+
   /// Whether incoming webhooks actually trigger action.
   #[serde(default = "default_webhook_enabled")]
   #[builder(default = "default_webhook_enabled()")]
@@ -358,6 +364,7 @@ impl Default for ResourceSyncConfig {
       branch: default_branch(),
       commit: Default::default(),
       git_account: Default::default(),
+      shallow_clone: Default::default(),
       resource_path: Default::default(),
       files_on_host: Default::default(),
       file_contents: Default::default(),

--- a/lib/git/src/clone.rs
+++ b/lib/git/src/clone.rs
@@ -68,8 +68,9 @@ where
     _ => {}
   }
 
+  let depth_flag = if args.shallow_clone { " --depth 1" } else { "" };
   let command = format!(
-    "git clone {repo_url} {} -b {}",
+    "git clone{depth_flag} {repo_url} {} -b {}",
     res.path.display(),
     args.branch
   );


### PR DESCRIPTION
## Summary

Adds a `shallow_clone` boolean option to Stack, Repo, Build, and ResourceSync configs. When enabled, `git clone` is invoked with `--depth 1`, significantly speeding up cloning of large repositories.

## Changes

- Added `shallow_clone: bool` field to `StackConfig`, `RepoConfig`, `BuildConfig`, and `ResourceSyncConfig`
- Wired the field through `RepoExecutionArgs`
- When `shallow_clone` is true, `--depth 1` is prepended to the git clone command
- Defaults to `false` (no behavior change for existing users)
- Available in TOML config and API types via serde/typeshare

Closes #1113