### PR TITLE
fix: prevent variable interpolation from replacing stack names

### DIFF
--- a/bin/core/src/alert/discord.rs
+++ b/bin/core/src/alert/discord.rs
@@ -259,7 +259,7 @@ pub async fn send_alert(
           .into_iter()
           .collect::<Vec<_>>();
         let sanitized_error =
-          svi::replace_in_string(&format!("{e:?}"), &replacers);
+          command::replace_in_string_word_boundary(&format!("{e:?}"), &replacers);
         anyhow::Error::msg(format!(
           "Error with slack request: {sanitized_error}"
         ))

--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -187,7 +187,7 @@ async fn send_custom_alert(
         .into_iter()
         .collect::<Vec<_>>();
       let sanitized_error =
-        svi::replace_in_string(&format!("{e:?}"), &replacers);
+        command::replace_in_string_word_boundary(&format!("{e:?}"), &replacers);
       anyhow::Error::msg(format!(
         "Error with request: {sanitized_error}"
       ))

--- a/bin/core/src/alert/slack.rs
+++ b/bin/core/src/alert/slack.rs
@@ -483,7 +483,7 @@ pub async fn send_alert(
         .into_iter()
         .collect::<Vec<_>>();
       let sanitized_error =
-        svi::replace_in_string(&format!("{e:?}"), &replacers);
+        command::replace_in_string_word_boundary(&format!("{e:?}"), &replacers);
       anyhow::Error::msg(format!(
         "Error with slack request: {sanitized_error}"
       ))

--- a/bin/core/src/api/execute/action.rs
+++ b/bin/core/src/api/execute/action.rs
@@ -177,9 +177,9 @@ impl Resolve<ExecuteArgs> for RunAction {
     )
     .await;
 
-    res.stdout = svi::replace_in_string(&res.stdout, &replacers)
+    res.stdout = command::replace_in_string_word_boundary(&res.stdout, &replacers)
       .replace(&key, "<ACTION_API_KEY>");
-    res.stderr = svi::replace_in_string(&res.stderr, &replacers)
+    res.stderr = command::replace_in_string_word_boundary(&res.stderr, &replacers)
       .replace(&secret, "<ACTION_API_SECRET>");
 
     cleanup_run(file + ".js", &path).await;

--- a/lib/command/Cargo.toml
+++ b/lib/command/Cargo.toml
@@ -9,5 +9,6 @@ homepage.workspace = true
 
 [dependencies]
 komodo_client.workspace = true
+regex.workspace = true
 run_command.workspace = true
 svi.workspace = true

--- a/lib/command/src/lib.rs
+++ b/lib/command/src/lib.rs
@@ -4,7 +4,65 @@ use komodo_client::{
   entities::{komodo_timestamp, update::Log},
   parsers::parse_multiline_command,
 };
+use regex::Regex;
 use run_command::{CommandOutput, async_run_command};
+
+/// A smarter replacement function that only replaces variable values
+/// when they appear as whole "tokens" — not as substrings of longer
+/// alphanumeric words. This prevents partial replacements in stack
+/// names, service names, paths, etc.
+///
+/// For example, if ESPHOME_USER=esp, this will NOT replace "esp" inside
+/// "esphome" but WILL replace a standalone "esp" (e.g. after a space,
+/// equals sign, or at string boundaries).
+///
+/// For values that start/end with word characters (\w), word boundaries
+/// (\b) are used. For values starting/ending with non-word characters
+/// (like paths), simple string replacement is used as a fallback since
+/// partial-match issues are unlikely for such values.
+pub fn replace_in_string_word_boundary<'a>(
+  input: &str,
+  replacers: impl IntoIterator<Item = &'a (String, String)>,
+) -> String {
+  let mut result = input.to_string();
+
+  for (to_replace, replacer) in replacers {
+    if to_replace.is_empty() {
+      continue;
+    }
+
+    let escaped = regex::escape(to_replace);
+
+    // Determine if we need word boundaries on each side.
+    // \b only works at transitions between \w and \W characters.
+    let first_is_word = to_replace
+      .chars()
+      .next()
+      .map_or(false, |c| c.is_alphanumeric() || c == '_');
+    let last_is_word = to_replace
+      .chars()
+      .last()
+      .map_or(false, |c| c.is_alphanumeric() || c == '_');
+
+    let pattern = format!(
+      "{}{}{}",
+      if first_is_word { r"\b" } else { "" },
+      escaped,
+      if last_is_word { r"\b" } else { "" },
+    );
+
+    if let Ok(re) = Regex::new(&pattern) {
+      let replacement_text = format!("<{}>", replacer);
+      result =
+        re.replace_all(&result, replacement_text.as_str()).to_string();
+    } else {
+      // Fall back to simple replacement if regex fails
+      result = result.replace(to_replace, &format!("<{replacer}>"));
+    }
+  }
+
+  result
+}
 
 pub async fn run_komodo_command(
   stage: &str,
@@ -62,9 +120,9 @@ pub async fn run_komodo_command_with_sanitization(
   }?;
 
   // Sanitize the command and output
-  log.command = svi::replace_in_string(&log.command, replacers);
-  log.stdout = svi::replace_in_string(&log.stdout, replacers);
-  log.stderr = svi::replace_in_string(&log.stderr, replacers);
+  log.command = replace_in_string_word_boundary(&log.command, replacers);
+  log.stdout = replace_in_string_word_boundary(&log.stdout, replacers);
+  log.stderr = replace_in_string_word_boundary(&log.stderr, replacers);
 
   Some(log)
 }


### PR DESCRIPTION
Fixes #628

## Problem
When a variable value is a substring of a stack/service name, the log output incorrectly replaces the stack name with the variable reference. For example, if `ESPHOME_USER=esp`, the stack name `esphome` gets displayed as `<ESPHOME_USER>home` in the compose command shown in logs.

## Root Cause
The `svi::replace_in_string` function performs naive `str::replace()` on the entire log string, replacing ALL occurrences of a variable's value — including partial matches within unrelated words like stack names, service names, and paths.

## Solution
Replaced all usages of `svi::replace_in_string` with a new `command::replace_in_string_word_boundary` function that uses regex word boundaries (`\b`) to ensure variable values are only replaced when they appear as complete tokens, not as substrings of longer words.

For values starting/ending with word characters (alphanumeric/underscore), word boundaries prevent partial matches. For values with non-word-character boundaries (like paths), the function still applies replacement since partial-match issues are unlikely for such values.

### Files Changed
- `lib/command/src/lib.rs` — Added `replace_in_string_word_boundary` function and updated local call sites
- `lib/command/Cargo.toml` — Added `regex` dependency
- `bin/core/src/alert/{mod,discord,slack}.rs` — Updated to use new function
- `bin/core/src/api/execute/action.rs` — Updated to use new function