### PR TITLE
fix: disable intrusive autocomplete and hover in compose editor

### DIFF
--- a/frontend/src/components/monaco.tsx
+++ b/frontend/src/components/monaco.tsx
@@ -154,7 +154,10 @@ export const MonacoEditor = ({
     readOnly,
     tabSize: 2,
     detectIndentation: true,
-    quickSuggestions: true,
+    quickSuggestions: false,
+    suggestOnTriggerCharacters: false,
+    parameterHints: { enabled: false },
+    hover: { enabled: false },
     padding: {
       top: 15,
     },


### PR DESCRIPTION
Fixes #1117

## Problem
The Monaco editor for compose files shows inline autocomplete suggestions and a compose specification hover popup that many users find disruptive to their workflow.

## Solution
Disabled quickSuggestions, hover popups, suggestOnTriggerCharacters, and parameter hints in the Monaco editor configuration.