### PR TITLE
fix: parse compose config before sanitization to prevent variable value replacement in service names

### DIFF
--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -527,28 +527,37 @@ impl Resolve<super::Args> for ComposeUp {
       let command = format!(
         "{docker_compose} -p {project_name} -f {file_args}{env_file_args} config",
       );
-      let Some(config_log) = run_komodo_command_with_sanitization(
+      // Run compose config without sanitization first, so we can
+      // parse service names from the raw output. Sanitization of
+      // secret values can replace substrings that appear in service
+      // names, image names, etc. (see moghtech/komodo#868).
+      let config_log = run_komodo_command(
         "Compose Config",
         run_directory.as_path(),
-        command,
-        false,
-        &replacers,
+        &command,
       )
-      .await
-      else {
-        // Only reachable if command is empty,
-        // not the case since it is provided above.
-        unreachable!()
-      };
+      .await;
       if !config_log.success {
-        res.logs.push(config_log);
+        // Sanitize before pushing to logs so secrets aren't exposed
+        let mut sanitized_log = config_log;
+        sanitized_log.command = svi::replace_in_string(&sanitized_log.command, &replacers);
+        sanitized_log.stdout = svi::replace_in_string(&sanitized_log.stdout, &replacers);
+        sanitized_log.stderr = svi::replace_in_string(&sanitized_log.stderr, &replacers);
+        res.logs.push(sanitized_log);
         return Ok(res);
       }
+      // Parse services from unsanitized output
       let compose =
         serde_yaml_ng::from_str::<ComposeFile>(&config_log.stdout)
           .context("Failed to parse compose contents")?;
-      // Record sanitized compose config output
-      res.compose_config = Some(config_log.stdout);
+      // Store sanitized config for display
+      res.compose_config = Some(svi::replace_in_string(&config_log.stdout, &replacers));
+      // Push sanitized log
+      let mut sanitized_log = config_log;
+      sanitized_log.command = svi::replace_in_string(&sanitized_log.command, &replacers);
+      sanitized_log.stdout = svi::replace_in_string(&sanitized_log.stdout, &replacers);
+      sanitized_log.stderr = svi::replace_in_string(&sanitized_log.stderr, &replacers);
+      res.logs.push(sanitized_log);
       for (
         service_name,
         ComposeService {


### PR DESCRIPTION
## Problem

When a stack uses secret variables whose values happen to be substrings of service names, image names, or other compose config fields, the sanitization step replaces ALL occurrences of those values with variable placeholders (e.g. `<SEMAPHORE__SEMAPHORE_DB_USER>`).

For example, with a variable `SEMAPHORE__SEMAPHORE_DB_USER=semaphore`, the string `semaphore` in the service name `semaphore`, image name `semaphoreui/semaphore:...`, and even the compose project name all get replaced with `<SEMAPHORE__SEMAPHORE_DB_USER>`, resulting in broken service name extraction and a corrupted 'Deployed Config' display.

## Root Cause

In the compose up handler, `run_komodo_command_with_sanitization` was used to run `docker compose config`. This sanitizes the stdout (replacing secret values with placeholders) **before** the output is parsed into a `ComposeFile` struct to extract service names, images, and container names.

## Fix

Run `docker compose config` via `run_komodo_command` (without sanitization) first, parse the `ComposeFile` from the raw output, then sanitize the output separately for display/logging. This ensures:

- Service names, images, and container names are extracted from the real compose config
- Secret values are still hidden in logs and the displayed 'Deployed Config'

Fixes #868