### PR TITLE
fix: improve error message for untrusted git server SSL certificates

### DIFF
--- a/lib/command/src/lib.rs
+++ b/lib/command/src/lib.rs
@@ -69,6 +69,36 @@ pub async fn run_komodo_command_with_sanitization(
   Some(log)
 }
 
+/// SSL-related error patterns that git may produce when the server's
+/// certificate is not trusted.
+const SSL_ERROR_PATTERNS: &[&str] = &[
+  "SSL certificate problem",
+  "server certificate verification failed",
+  "unable to access",
+];
+
+const SSL_HELP_MESSAGE: &str = concat!(
+  "\n\nNote: This error may be caused by an untrusted SSL certificate on the git server. ",
+  "To resolve this, either:\n",
+  "  1. Add the server's CA certificate to the system trust store, or\n",
+  "  2. Set the GIT_SSL_CAINFO environment variable to point to your CA bundle, or\n",
+  "  3. Set GIT_SSL_NO_VERIFY=true (not recommended for production) to skip certificate verification.",
+);
+
+/// If the stderr contains signs of an SSL/TLS certificate error,
+/// append a human-friendly help message.
+fn maybe_enrich_ssl_error(stderr: String) -> String {
+  let lower = stderr.to_lowercase();
+  let is_ssl_error = SSL_ERROR_PATTERNS
+    .iter()
+    .any(|p| lower.contains(&p.to_lowercase()));
+  if is_ssl_error {
+    format!("{stderr}{SSL_HELP_MESSAGE}")
+  } else {
+    stderr
+  }
+}
+
 pub fn output_into_log(
   stage: &str,
   command: String,
@@ -79,7 +109,7 @@ pub fn output_into_log(
   Log {
     stage: stage.to_string(),
     stdout: output.stdout,
-    stderr: output.stderr,
+    stderr: maybe_enrich_ssl_error(output.stderr),
     command,
     success,
     start_ts,


### PR DESCRIPTION
## Problem

When a git server's SSL certificate is not trusted, Komodo gives an obscure, unhelpful error message that doesn't indicate the root cause.

Closes #1028

## Solution

Added SSL error detection in the central `output_into_log` function in `lib/command/src/lib.rs`. When git command stderr contains SSL-related error patterns (e.g., "SSL certificate problem", "server certificate verification failed"), a helpful message is appended suggesting the user:

1. Add the server's CA certificate to the system trust store
2. Set the `GIT_SSL_CAINFO` environment variable to point to their CA bundle
3. Set `GIT_SSL_NO_VERIFY=true` (with a warning that this is not recommended for production)

This covers all git operations (clone, pull, fetch, etc.) since they all flow through `run_komodo_command` → `output_into_log`.