### PR TITLE
fix: reduce excessive logging from status polling and health checks

### DIFF
--- a/bin/core/src/api/write/mod.rs
+++ b/bin/core/src/api/write/mod.rs
@@ -239,7 +239,7 @@ async fn task(
   request: WriteRequest,
   user: User,
 ) -> serror::Result<axum::response::Response> {
-  info!("/write request | user: {}", user.username);
+  debug!("/write request | user: {}", user.username);
 
   let timer = Instant::now();
 

--- a/bin/core/src/api/write/stack.rs
+++ b/bin/core/src/api/write/stack.rs
@@ -457,7 +457,7 @@ impl Resolve<WriteArgs> for RefreshStackCache {
             &contents.contents,
             &mut services,
           ) {
-            warn!(
+            debug!(
               "failed to extract stack services, things won't works correctly. stack: {} | {e:#}",
               stack.name
             );
@@ -499,7 +499,7 @@ impl Resolve<WriteArgs> for RefreshStackCache {
           &contents.contents,
           &mut services,
         ) {
-          warn!(
+          debug!(
             "failed to extract stack services, things won't works correctly. stack: {} | {e:#}",
             stack.name
           );
@@ -524,7 +524,7 @@ impl Resolve<WriteArgs> for RefreshStackCache {
         &stack.config.file_contents,
         &mut services,
       ) {
-        warn!(
+        debug!(
           "Failed to extract Stack services for {}, things may not work correctly. | {e:#}",
           stack.name
         );

--- a/bin/core/src/monitor/resources.rs
+++ b/bin/core/src/monitor/resources.rs
@@ -248,7 +248,7 @@ pub async fn update_stack_cache(
         {
           Ok(regex) => regex,
           Err(e) => {
-            warn!("{e:#}");
+            debug!("{e:#}");
             return false
           }
         }.is_match(&container.name)

--- a/bin/core/src/resource/action.rs
+++ b/bin/core/src/resource/action.rs
@@ -214,7 +214,7 @@ async fn get_action_state_from_db(id: &str) -> ActionState {
   }
   .await
   .inspect_err(|e| {
-    warn!("Failed to get Action state for {id} | {e:#}")
+    debug!("Failed to get Action state for {id} | {e:#}")
   })
   .unwrap_or(ActionState::Unknown)
 }

--- a/bin/core/src/resource/build.rs
+++ b/bin/core/src/resource/build.rs
@@ -353,7 +353,7 @@ async fn get_build_state_from_db(id: &str) -> BuildState {
   }
   .await
   .inspect_err(|e| {
-    warn!("failed to get build state for {id} | {e:#}")
+    debug!("failed to get build state for {id} | {e:#}")
   })
   .unwrap_or(BuildState::Unknown)
 }

--- a/bin/core/src/resource/procedure.rs
+++ b/bin/core/src/resource/procedure.rs
@@ -837,7 +837,7 @@ async fn get_procedure_state_from_db(id: &str) -> ProcedureState {
   }
   .await
   .inspect_err(|e| {
-    warn!("Failed to get Procedure state for {id} | {e:#}")
+    debug!("Failed to get Procedure state for {id} | {e:#}")
   })
   .unwrap_or(ProcedureState::Unknown)
 }

--- a/bin/core/src/resource/refresh.rs
+++ b/bin/core/src/resource/refresh.rs
@@ -66,7 +66,7 @@ async fn refresh_stacks() {
   let Ok(stacks) = find_collect(&db_client().stacks, None, None)
     .await
     .inspect_err(|e| {
-      warn!(
+      debug!(
         "Failed to get Stacks from database in refresh task | {e:#}"
       )
     })
@@ -80,7 +80,7 @@ async fn refresh_stacks() {
       )
       .await
       .inspect_err(|e| {
-        warn!("Failed to refresh Stack cache in refresh task | Stack: {} | {:#}", stack.name, e.error)
+        debug!("Failed to refresh Stack cache in refresh task | Stack: {} | {:#}", stack.name, e.error)
       })
       .ok();
   }
@@ -90,7 +90,7 @@ async fn refresh_builds() {
   let Ok(builds) = find_collect(&db_client().builds, None, None)
     .await
     .inspect_err(|e| {
-      warn!(
+      debug!(
         "Failed to get Builds from database in refresh task | {e:#}"
       )
     })
@@ -104,7 +104,7 @@ async fn refresh_builds() {
       )
       .await
       .inspect_err(|e| {
-        warn!("Failed to refresh Build cache in refresh task | Build: {} | {:#}", build.name, e.error)
+        debug!("Failed to refresh Build cache in refresh task | Build: {} | {:#}", build.name, e.error)
       })
       .ok();
   }
@@ -114,7 +114,7 @@ async fn refresh_repos() {
   let Ok(repos) = find_collect(&db_client().repos, None, None)
     .await
     .inspect_err(|e| {
-      warn!(
+      debug!(
         "Failed to get Repos from database in refresh task | {e:#}"
       )
     })
@@ -128,7 +128,7 @@ async fn refresh_repos() {
       )
       .await
       .inspect_err(|e| {
-        warn!("Failed to refresh Repo cache in refresh task | Repo: {} | {:#}", repo.name, e.error)
+        debug!("Failed to refresh Repo cache in refresh task | Repo: {} | {:#}", repo.name, e.error)
       })
       .ok();
   }
@@ -142,7 +142,7 @@ async fn refresh_syncs() {
   )
   .await
   .inspect_err(|e| {
-    warn!(
+    debug!(
       "failed to get resource syncs from db in refresh task | {e:#}"
     )
   }) else {
@@ -155,7 +155,7 @@ async fn refresh_syncs() {
       )
       .await
       .inspect_err(|e| {
-        warn!("Failed to refresh ResourceSync in refresh task | Sync: {} | {:#}", sync.name, e.error)
+        debug!("Failed to refresh ResourceSync in refresh task | Sync: {} | {:#}", sync.name, e.error)
       })
       .ok();
   }

--- a/bin/core/src/resource/repo.rs
+++ b/bin/core/src/resource/repo.rs
@@ -227,7 +227,7 @@ pub async fn refresh_repo_state_cache() {
   }
   .await
   .inspect_err(|e| {
-    warn!("failed to refresh repo state cache | {e:#}")
+    debug!("failed to refresh repo state cache | {e:#}")
   });
 }
 
@@ -320,6 +320,6 @@ async fn get_repo_state_from_db(id: &str) -> RepoState {
     anyhow::Ok(state)
   }
   .await
-  .inspect_err(|e| warn!("failed to get repo state for {id} | {e:#}"))
+  .inspect_err(|e| debug!("failed to get repo state for {id} | {e:#}"))
   .unwrap_or(RepoState::Unknown)
 }


### PR DESCRIPTION
## Problem

Komodo generates excessive logs (300k+ in 24 hours), filling up storage. The primary sources are high-frequency polling operations that log at `info!` or `warn!` level on every cycle.

## Root Cause

With the default `monitoring_interval` of 15 seconds (5,760 cycles/day), several log statements fire on every polling cycle for every resource:

1. **`/write request` handler** logged at `info!` — every resource refresh triggers write requests for each stack/build/repo/sync, generating an info log per resource per cycle
2. **Resource refresh loop errors** logged at `warn!` — persistent DB or cache errors fire on every poll cycle for every resource
3. **Stack service extraction failures** logged at `warn!` — fires every refresh cycle for stacks with parsing issues
4. **Container regex match failures** logged at `warn!` — fires every 15s monitoring cycle per service
5. **Resource state cache errors** (build/repo/procedure/action) logged at `warn!` — fires every 60s per resource on persistent errors

## Fix

Move all high-frequency polling log statements from `info!`/`warn!` to `debug!` level. This dramatically reduces log volume at the default `info` log level while preserving all diagnostic information when `debug` level is enabled.

### Files Changed
- `bin/core/src/api/write/mod.rs` — write request logging: `info!` → `debug!`
- `bin/core/src/api/write/stack.rs` — service extraction warnings: `warn!` → `debug!`
- `bin/core/src/monitor/resources.rs` — container regex match: `warn!` → `debug!`
- `bin/core/src/resource/refresh.rs` — all refresh loop errors: `warn!` → `debug!`
- `bin/core/src/resource/build.rs` — build state cache errors: `warn!` → `debug!`
- `bin/core/src/resource/repo.rs` — repo state cache errors: `warn!` → `debug!`
- `bin/core/src/resource/procedure.rs` — procedure state errors: `warn!` → `debug!`
- `bin/core/src/resource/action.rs` — action state errors: `warn!` → `debug!`

Fixes #1115