### PR TITLE
fix: filter build update logs by user resource permissions

### DIFF
--- a/bin/core/src/api/read/update.rs
+++ b/bin/core/src/api/read/update.rs
@@ -139,8 +139,7 @@ impl Resolve<ReadArgs> for ListUpdates {
       })
       .unwrap_or_else(|| doc! { "target.type": "ResourceSync" });
 
-      let mut query = self.query.unwrap_or_default();
-      query.extend(doc! {
+      let permission_filter = doc! {
         "$or": [
           server_query,
           deployment_query,
@@ -153,8 +152,18 @@ impl Resolve<ReadArgs> for ListUpdates {
           builder_query,
           resource_sync_query,
         ]
-      });
-      query.into()
+      };
+      let user_query = self.query.unwrap_or_default();
+      if user_query.is_empty() {
+        Some(permission_filter)
+      } else {
+        Some(doc! {
+          "$and": [
+            user_query,
+            permission_filter,
+          ]
+        })
+      }
     };
 
     let usernames = find_collect(&db_client().users, None, None)


### PR DESCRIPTION
## Problem

Non-admin users see Run Build update logs from other deployments in the Updates window (issue #1011).

## Root Cause

In `ListUpdates`, when a non-admin user's query contains a `$or` filter (e.g., when viewing a deployment page that shows associated build updates), the permission filter's `$or` overwrites the user's `$or` via `Document::extend()`. This causes the user's resource-specific filter to be lost, showing all updates the user has permission on rather than the filtered subset.

For example, when viewing a deployment page:
1. Frontend sends `{ $or: [deployment_filter, build_filter] }`
2. Backend calls `query.extend(doc! { $or: [permission_filters] })`
3. The permission `$or` **replaces** the user's `$or`
4. User sees all permitted updates instead of just that deployment's updates

## Fix

Use `$and` to combine the user query with the permission filter, preserving both constraints:
- The user's filter (which resource to show)
- The permission filter (which resources the user can access)

Fixes #1011