### PR TITLE
fix: interpolate variables and secrets in Pushover alerter URL

### DIFF
--- a/bin/core/src/alert/pushover.rs
+++ b/bin/core/src/alert/pushover.rs
@@ -9,7 +9,28 @@ pub async fn send_alert(
 ) -> anyhow::Result<()> {
   let content = standard_alert_content(alert);
   if !content.is_empty() {
-    send_message(url, content).await?;
+    let VariablesAndSecrets { variables, secrets } =
+      get_variables_and_secrets().await?;
+    let mut url_interpolated = url.to_string();
+
+    let mut interpolator =
+      Interpolator::new(Some(&variables), &secrets);
+
+    interpolator.interpolate_string(&mut url_interpolated)?;
+
+    send_message(&url_interpolated, content)
+      .await
+      .map_err(|e| {
+        let replacers = interpolator
+          .secret_replacers
+          .into_iter()
+          .collect::<Vec<_>>();
+        let sanitized_error =
+          svi::replace_in_string(&format!("{e:?}"), &replacers);
+        anyhow::Error::msg(format!(
+          "Error with pushover request: {sanitized_error}"
+        ))
+      })?;
   }
   Ok(())
 }


### PR DESCRIPTION
## Problem

When using Komodo variables/secrets (e.g. `[[MY_PUSHOVER_TOKEN]]`) in Pushover alerter configuration, the variables were not being interpolated before sending to the Pushover API, causing authentication failures.

## Fix

Add variable/secret interpolation to the Pushover alerter's `send_alert` function, matching the existing pattern used by Discord and Slack alerters. This includes:

- Resolving variables and secrets via `get_variables_and_secrets()`
- Interpolating the URL string before use
- Sanitizing secrets from error messages to prevent leakage

## Testing

The change follows the exact same pattern as the Discord and Slack alerters which are already working correctly with variable interpolation.

Closes #1051