### PR TITLE
fix: refresh login options when OIDC client is re-initialized

### DIFF
--- a/bin/core/src/api/auth.rs
+++ b/bin/core/src/api/auth.rs
@@ -1,4 +1,4 @@
-use std::{sync::OnceLock, time::Instant};
+use std::time::Instant;
 
 use axum::{Router, extract::Path, http::HeaderMap, routing::post};
 use derive_variants::{EnumVariants, ExtractVariant};
@@ -108,20 +108,15 @@ async fn handler(
   res.map(|res| res.0)
 }
 
-fn login_options_reponse() -> &'static GetLoginOptionsResponse {
-  static GET_LOGIN_OPTIONS_RESPONSE: OnceLock<
-    GetLoginOptionsResponse,
-  > = OnceLock::new();
-  GET_LOGIN_OPTIONS_RESPONSE.get_or_init(|| {
-    let config = core_config();
-    GetLoginOptionsResponse {
-      local: config.local_auth,
-      github: github_oauth_client().is_some(),
-      google: google_oauth_client().is_some(),
-      oidc: oidc_client().load().is_some(),
-      registration_disabled: config.disable_user_registration,
-    }
-  })
+fn login_options_response() -> GetLoginOptionsResponse {
+  let config = core_config();
+  GetLoginOptionsResponse {
+    local: config.local_auth,
+    github: github_oauth_client().is_some(),
+    google: google_oauth_client().is_some(),
+    oidc: oidc_client().load().is_some(),
+    registration_disabled: config.disable_user_registration,
+  }
 }
 
 impl Resolve<AuthArgs> for GetLoginOptions {
@@ -130,7 +125,7 @@ impl Resolve<AuthArgs> for GetLoginOptions {
     self,
     _: &AuthArgs,
   ) -> serror::Result<GetLoginOptionsResponse> {
-    Ok(*login_options_reponse())
+    Ok(login_options_response())
   }
 }
 

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -123,6 +123,7 @@ export const useLoginOptions = () => {
   return useQuery({
     queryKey: ["GetLoginOptions"],
     queryFn: () => komodo_client().auth("GetLoginOptions", {}),
+    refetchInterval: 30_000,
   });
 };
 


### PR DESCRIPTION
## Problem

When OIDC configuration is changed and re-initialized at runtime, the UI doesn't reflect the new state — users see stale OIDC buttons or missing login options, requiring a hard browser refresh.

## Root Cause

The `GetLoginOptions` API response was cached in a `OnceLock`, computed once at server startup and never updated. The OIDC client itself uses `ArcSwap` for dynamic updates, but the login options endpoint returned the stale cached snapshot.

## Fix

**Backend:** Replace the static `OnceLock` cache with a function that reads the current OIDC client state on each request. The `oidc_client().load().is_some()` check now reflects the live `ArcSwap` value.

**Frontend:** Add a 30-second polling interval to the login options query so the login page automatically picks up server-side changes without requiring a hard refresh.

Fixes #1022