### PR TITLE
fix: retry file reads for dynamically created files

### DIFF
--- a/bin/core/src/stack/remote.rs
+++ b/bin/core/src/stack/remote.rs
@@ -47,10 +47,24 @@ pub async fn get_repo_compose_contents(
     {
       missing_files.push(file.path.clone());
     }
-    // If file does not exist, will show up in err case so the log is handled
-    match fs::read_to_string(&file_path).with_context(|| {
-      format!("Failed to read file contents from {file_path:?}")
-    }) {
+    // If file does not exist, will show up in err case so the log is handled.
+    // Retry briefly for files that may still be materialising on disk.
+    let read_result = {
+      let mut result = fs::read_to_string(&file_path);
+      if result.is_err() {
+        for _ in 0..3 {
+          std::thread::sleep(std::time::Duration::from_millis(500));
+          result = fs::read_to_string(&file_path);
+          if result.is_ok() {
+            break;
+          }
+        }
+      }
+      result.with_context(|| {
+        format!("Failed to read file contents from {file_path:?}")
+      })
+    };
+    match read_result {
       Ok(contents) => successful.push(StackRemoteFileContents {
         path: file.path,
         contents,

--- a/bin/periphery/src/compose/up.rs
+++ b/bin/periphery/src/compose/up.rs
@@ -12,6 +12,45 @@ use tokio::fs;
 
 use crate::docker::docker_login;
 
+/// Maximum number of retry attempts when reading a file that may have
+/// been dynamically created (e.g. by a deploy hook or write_stack).
+const FILE_READ_MAX_RETRIES: u32 = 3;
+/// Delay between retry attempts.
+const FILE_READ_RETRY_DELAY: std::time::Duration =
+  std::time::Duration::from_millis(500);
+
+/// Try to read a file, retrying a few times if it does not exist yet.
+/// This handles the race condition where the filesystem has not yet
+/// synced after a file is dynamically created.
+async fn read_file_with_retry(
+  path: &Path,
+) -> Result<String, anyhow::Error> {
+  let mut last_err = None;
+  for attempt in 0..=FILE_READ_MAX_RETRIES {
+    if attempt > 0 {
+      tokio::time::sleep(FILE_READ_RETRY_DELAY).await;
+    }
+    match fs::read_to_string(path).await {
+      Ok(contents) => return Ok(contents),
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        last_err = Some(e);
+        // File may not exist yet — retry
+        continue;
+      }
+      Err(e) => {
+        return Err(anyhow::Error::new(e).context(format!(
+          "Failed to read file contents at {path:?}"
+        )));
+      }
+    }
+  }
+  Err(
+    anyhow::Error::new(last_err.unwrap()).context(format!(
+      "Failed to read file contents at {path:?} (file not found after {FILE_READ_MAX_RETRIES} retries)"
+    )),
+  )
+}
+
 pub async fn validate_files(
   stack: &Stack,
   run_directory: &Path,
@@ -32,9 +71,20 @@ pub async fn validate_files(
     })
     .collect::<Vec<_>>();
 
-  // First validate no missing files
+  // First validate no missing files, retrying briefly for files that
+  // may still be materialising on disk after write_stack.
   for (full_path, file) in &file_paths {
-    if !full_path.exists() {
+    let mut exists = full_path.exists();
+    if !exists {
+      for _ in 0..FILE_READ_MAX_RETRIES {
+        tokio::time::sleep(FILE_READ_RETRY_DELAY).await;
+        exists = full_path.exists();
+        if exists {
+          break;
+        }
+      }
+    }
+    if !exists {
       res.missing_files.push(file.path.clone());
     }
   }
@@ -54,24 +104,21 @@ pub async fn validate_files(
   }
 
   for (full_path, file) in file_paths {
-    let file_contents =
-      match fs::read_to_string(&full_path).await.with_context(|| {
-        format!("Failed to read file contents at {full_path:?}")
-      }) {
-        Ok(res) => res,
-        Err(e) => {
-          let error = format_serror(&e.into());
-          res
-            .logs
-            .push(Log::error("Read Compose File", error.clone()));
-          // This should only happen for repo stacks, ie remote error
-          res.remote_errors.push(FileContents {
-            path: file.path,
-            contents: error,
-          });
-          return;
-        }
-      };
+    let file_contents = match read_file_with_retry(&full_path).await {
+      Ok(res) => res,
+      Err(e) => {
+        let error = format_serror(&e.into());
+        res
+          .logs
+          .push(Log::error("Read Compose File", error.clone()));
+        // This should only happen for repo stacks, ie remote error
+        res.remote_errors.push(FileContents {
+          path: file.path,
+          contents: error,
+        });
+        return;
+      }
+    };
     res.file_contents.push(StackRemoteFileContents {
       path: file.path,
       contents: file_contents,


### PR DESCRIPTION
## Problem

When a file is dynamically created (e.g., by a deploy hook or script), Komodo throws "Failed to read file contents" because it tries to read the file before it exists or before the filesystem has synced.

## Solution

Add retry logic (up to 3 attempts with 500ms delay) for file existence checks and file reads in:

- **`bin/periphery/src/compose/up.rs`** — `validate_files()` now retries both the existence check and the file read via a new `read_file_with_retry()` helper. Only `NotFound` errors trigger retries; other I/O errors fail immediately.
- **`bin/core/src/stack/remote.rs`** — `get_repo_compose_contents()` retries file reads with the same strategy.

This gracefully handles filesystem sync delays without masking real errors.

Fixes #987