### PR TITLE
fix: allow committing UI changes when resource_path is a directory

### DIFF
--- a/bin/core/src/api/write/sync.rs
+++ b/bin/core/src/api/write/sync.rs
@@ -442,15 +442,15 @@ impl Resolve<WriteArgs> for CommitSync {
         .parse::<PathBuf>()
         .context("Invalid resource path")?;
 
-      if resource_path
-        .extension()
-        .context("Resource path missing '.toml' extension")?
-        != "toml"
-      {
-        return Err(
-          anyhow!("Resource path missing '.toml' extension").into(),
-        );
-      }
+      // If resource_path points to a directory (no .toml extension),
+      // write to a default file inside it.
+      let resource_path =
+        if resource_path.extension().is_some_and(|ext| ext == "toml")
+        {
+          resource_path
+        } else {
+          resource_path.join("resources.toml")
+        };
       Some(resource_path)
     } else {
       None


### PR DESCRIPTION
## Problem

When `resource_path` is configured as a directory instead of a single file, committing UI changes via `CommitSync` fails because the code requires the path to have a `.toml` extension.

The **read** side already handles directories correctly — it recursively reads all `.toml` files from the directory. But the **write/commit** side rejects any path without a `.toml` extension.

## Fix

Instead of rejecting paths without a `.toml` extension, when `resource_path` doesn't end in `.toml` (i.e. it's a directory), the commit now writes to a default `resources.toml` file inside that directory.

This is consistent with how users would set up a directory-based resource sync — the exported resources get written to `<directory>/resources.toml`, which is then picked up on the next read.

Fixes #978