### PR TITLE
fix: reject absolute resource_path to prevent filesystem root scan

### DIFF
--- a/bin/core/src/api/write/sync.rs
+++ b/bin/core/src/api/write/sync.rs
@@ -194,7 +194,19 @@ async fn write_sync_file_contents_on_host(
   let resource_path = resource_path
     .parse::<PathBuf>()
     .context("Invalid resource path")?;
+  if resource_path.is_absolute() {
+    return Err(
+      anyhow!("Resource path must be relative, not absolute")
+        .into(),
+    );
+  }
   let full_path = root.join(&resource_path).join(&file_path);
+  if !full_path.starts_with(&root) {
+    return Err(
+      anyhow!("Resource path must not escape the root directory")
+        .into(),
+    );
+  }
 
   if let Some(parent) = full_path.parent() {
     tokio::fs::create_dir_all(parent).await.with_context(|| {
@@ -283,6 +295,12 @@ async fn write_sync_file_contents_git(
     resource_path.parse::<PathBuf>().with_context(|| {
       format!("Resource path is not a valid path: {resource_path}")
     })?;
+  if resource_path.is_absolute() {
+    return Err(
+      anyhow!("Resource path must be relative, not absolute")
+        .into(),
+    );
+  }
   let full_path = root
     .join(&resource_path)
     .join(&file_path)

--- a/bin/core/src/sync/file.rs
+++ b/bin/core/src/sync/file.rs
@@ -25,10 +25,61 @@ pub fn read_resources(
     let resource_path = resource_path
       .parse::<PathBuf>()
       .context("Invalid resource path")?;
+
+    // Reject absolute paths (e.g. "/") - joining an absolute path
+    // replaces the base entirely, which would scan the filesystem root.
+    if resource_path.is_absolute() {
+      file_errors.push(SyncFileContents {
+        resource_path: String::new(),
+        path: resource_path.display().to_string(),
+        contents: format_serror(
+          &anyhow!(
+            "Resource path must be relative, not absolute. \
+             Got: {:?}",
+            resource_path
+          )
+          .into(),
+        ),
+      });
+      logs.push(Log::error(
+        "Read remote resources",
+        format!(
+          "{}: Resource path {:?} is absolute and not allowed.",
+          colored("ERROR", Color::Red),
+          resource_path.display()
+        ),
+      ));
+      continue;
+    }
+
+    // Reject paths that would escape the root via ".." components.
     let full_path = root_path
       .join(&resource_path)
       .components()
       .collect::<PathBuf>();
+    if !full_path.starts_with(root_path) {
+      file_errors.push(SyncFileContents {
+        resource_path: String::new(),
+        path: resource_path.display().to_string(),
+        contents: format_serror(
+          &anyhow!(
+            "Resource path must not escape the root directory. \
+             Got: {:?}",
+            resource_path
+          )
+          .into(),
+        ),
+      });
+      logs.push(Log::error(
+        "Read remote resources",
+        format!(
+          "{}: Resource path {:?} escapes the root directory.",
+          colored("ERROR", Color::Red),
+          resource_path.display()
+        ),
+      ));
+      continue;
+    }
 
     let mut log = format!(
       "{}: reading resources from {full_path:?}",

--- a/frontend/src/components/resources/resource-sync/config.tsx
+++ b/frontend/src/components/resources/resource-sync/config.tsx
@@ -254,10 +254,19 @@ export const ResourceSyncConfig = ({
               <ConfigList
                 label="Resource Paths"
                 addLabel="Add Path"
-                description="Add '.toml' files or folders to the sync. Relative to '/syncs/{sync_name}'."
+                description="Add '.toml' files or folders to the sync. Relative to '/syncs/{sync_name}'. Must be relative paths (no leading '/')."
                 field="resource_path"
                 values={values ?? []}
-                set={set}
+                set={(update) => {
+                  // Sanitize: strip leading slashes to prevent absolute paths
+                  // which would cause the backend to scan from filesystem root.
+                  if (update.resource_path) {
+                    update.resource_path = update.resource_path.map(
+                      (p) => p.replace(/^\/+/, "")
+                    );
+                  }
+                  set(update);
+                }}
                 disabled={disabled}
                 placeholder="Input resource path"
               />
@@ -516,10 +525,19 @@ export const ResourceSyncConfig = ({
               <ConfigList
                 label="Resource Paths"
                 addLabel="Add Path"
-                description="Add '.toml' files or folders to the sync. Relative to the root of the repo."
+                description="Add '.toml' files or folders to the sync. Relative to the root of the repo. Must be relative paths (no leading '/')."
                 field="resource_path"
                 values={values ?? []}
-                set={set}
+                set={(update) => {
+                  // Sanitize: strip leading slashes to prevent absolute paths
+                  // which would cause the backend to scan from filesystem root.
+                  if (update.resource_path) {
+                    update.resource_path = update.resource_path.map(
+                      (p) => p.replace(/^\/+/, "")
+                    );
+                  }
+                  set(update);
+                }}
                 disabled={disabled}
                 placeholder="Input resource path"
               />


### PR DESCRIPTION
## Problem

When `resource_path` is set to `/` (or any absolute path), Rust's `PathBuf::join` replaces the base path entirely, causing the sync to recursively scan from the filesystem root. This hangs the backend and makes the entire UI unresponsive with an infinite loading spinner. The only recovery is to manually edit MongoDB.

## Root Cause

`PathBuf::join("/")` in Rust replaces the base path, so `root_path.join("/")` becomes `/` instead of `root_path/`. The backend then attempts to recursively read the entire filesystem as resource files.

## Fix

**Backend** (`bin/core/src/sync/file.rs`, `bin/core/src/api/write/sync.rs`):
- Validate that `resource_path` is relative before joining with root path
- Reject absolute paths with a clear error message
- Reject paths that escape the root directory via `..` traversal

**Frontend** (`frontend/src/components/resources/resource-sync/config.tsx`):
- Strip leading slashes from resource_path input fields
- Updated descriptions to clarify paths must be relative

Fixes #999