### PR TITLE
fix: include main .env file in stack Info GUI when environment is configured

### DIFF
--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -72,6 +72,10 @@ impl Stack {
       .cloned()
       // Makes sure to dedup them, while maintaining ordering
       .collect::<IndexSet<_>>();
+    // Include the main env file when environment variables are defined
+    if !self.config.environment.is_empty() {
+      res.insert(self.config.env_file_path.clone());
+    }
     res.extend(self.config.additional_env_files.clone());
     res.extend(
       self.config.config_files.iter().map(|f| f.path.clone()),
@@ -87,6 +91,12 @@ impl Stack {
       .map(StackFileDependency::full_redeploy)
       // Makes sure to dedup them, while maintaining ordering
       .collect::<IndexSet<_>>();
+    // Include the main env file when environment variables are defined
+    if !self.config.environment.is_empty() {
+      res.insert(StackFileDependency::full_redeploy(
+        self.config.env_file_path.clone(),
+      ));
+    }
     res.extend(
       self
         .config


### PR DESCRIPTION
## Problem

When a stack has environment variables defined in its configuration, Komodo generates a `.env` file (at the path specified by `env_file_path`, defaulting to `.env`). However, this file was not displayed in the Stack Info GUI unless the user redundantly added it to "Additional Env Files".

## Root Cause

The `all_file_paths()` and `all_file_dependencies()` methods on `Stack` included compose files, additional env files, and config files — but not the main `env_file_path` that gets generated from the `environment` configuration.

## Fix

When `environment` is non-empty, automatically include `env_file_path` in both `all_file_paths()` and `all_file_dependencies()`. This uses `IndexSet` so duplicates are handled if the path already appears elsewhere.

Fixes #990