### PR TITLE
fix: surface git errors in Global Auto Update and resource refresh

### DIFF
--- a/bin/core/src/api/execute/maintenance.rs
+++ b/bin/core/src/api/execute/maintenance.rs
@@ -9,6 +9,7 @@ use komodo_client::{
     BackupCoreDatabase, ClearRepoCache, GlobalAutoUpdate,
   },
   entities::{
+    all_logs_success,
     deployment::DeploymentState, server::ServerState,
     stack::StackState,
   },
@@ -247,21 +248,44 @@ impl Resolve<ExecuteArgs> for GlobalAutoUpdate {
           };
           Some(repo.clone())
         };
-        if let Err(e) =
-          pull_stack_inner(stack, Vec::new(), server, repo, None)
+        match pull_stack_inner(stack, Vec::new(), server, repo, None)
             .await
         {
-          update.push_error_log(
-            &format!("Pull Stack {name}"),
-            format_serror(&e.into()),
-          );
-        } else {
-          if !update.logs[0].stdout.is_empty() {
-            update.logs[0].stdout.push('\n');
+          Err(e) => {
+            update.push_error_log(
+              &format!("Pull Stack {name}"),
+              format_serror(&e.into()),
+            );
           }
-          update.logs[0]
-            .stdout
-            .push_str(&format!("Pulled Stack {} ✅", bold(name)));
+          Ok(res) if !all_logs_success(&res.logs) => {
+            let failed_logs: Vec<_> = res.logs.iter()
+              .filter(|l| !l.success)
+              .collect();
+            let error_msg = failed_logs.iter()
+              .map(|l| {
+                let mut msg = format!("[{}]", l.stage);
+                if !l.stderr.is_empty() {
+                  msg.push_str(&format!(" {}", l.stderr));
+                } else if !l.stdout.is_empty() {
+                  msg.push_str(&format!(" {}", l.stdout));
+                }
+                msg
+              })
+              .collect::<Vec<_>>()
+              .join("\n");
+            update.push_error_log(
+              &format!("Pull Stack {name}"),
+              error_msg,
+            );
+          }
+          Ok(_) => {
+            if !update.logs[0].stdout.is_empty() {
+              update.logs[0].stdout.push('\n');
+            }
+            update.logs[0]
+              .stdout
+              .push_str(&format!("Pulled Stack {} ✅", bold(name)));
+          }
         }
       }
     }
@@ -292,21 +316,34 @@ impl Resolve<ExecuteArgs> for GlobalAutoUpdate {
           .unwrap_or_default()
       {
         let name = deployment.name.clone();
-        if let Err(e) =
-          pull_deployment_inner(deployment, server).await
+        match pull_deployment_inner(deployment, server).await
         {
-          update.push_error_log(
-            &format!("Pull Deployment {name}"),
-            format_serror(&e.into()),
-          );
-        } else {
-          if !update.logs[0].stdout.is_empty() {
-            update.logs[0].stdout.push('\n');
+          Err(e) => {
+            update.push_error_log(
+              &format!("Pull Deployment {name}"),
+              format_serror(&e.into()),
+            );
           }
-          update.logs[0].stdout.push_str(&format!(
-            "Pulled Deployment {} ✅",
-            bold(name)
-          ));
+          Ok(log) if !log.success => {
+            let error_msg = if !log.stderr.is_empty() {
+              log.stderr
+            } else {
+              log.stdout
+            };
+            update.push_error_log(
+              &format!("Pull Deployment {name}"),
+              error_msg,
+            );
+          }
+          Ok(_) => {
+            if !update.logs[0].stdout.is_empty() {
+              update.logs[0].stdout.push('\n');
+            }
+            update.logs[0].stdout.push_str(&format!(
+              "Pulled Deployment {} ✅",
+              bold(name)
+            ));
+          }
         }
       }
     }

--- a/bin/core/src/api/write/repo.rs
+++ b/bin/core/src/api/write/repo.rs
@@ -7,7 +7,7 @@ use formatting::format_serror;
 use komodo_client::{
   api::write::*,
   entities::{
-    NoData, Operation, RepoExecutionArgs,
+    NoData, Operation, RepoExecutionArgs, all_logs_success,
     config::core::CoreConfig,
     komodo_timestamp,
     permission::PermissionLevel,
@@ -207,6 +207,27 @@ impl Resolve<WriteArgs> for RefreshRepoCache {
     .with_context(|| {
       format!("Failed to update repo at {repo_path:?}")
     })?;
+
+    if !all_logs_success(&res.logs) {
+      let failed_stages: Vec<_> = res.logs.iter()
+        .filter(|l| !l.success)
+        .map(|l| {
+          let detail = if !l.stderr.is_empty() {
+            &l.stderr
+          } else {
+            &l.stdout
+          };
+          format!("[{}] {}", l.stage, detail)
+        })
+        .collect();
+      return Err(
+        anyhow!(
+          "Git operation failed for repo {}:\n{}",
+          repo.name,
+          failed_stages.join("\n")
+        ).into()
+      );
+    }
 
     let info = RepoInfo {
       last_pulled_at: repo.info.last_pulled_at,

--- a/bin/core/src/stack/remote.rs
+++ b/bin/core/src/stack/remote.rs
@@ -1,9 +1,9 @@
 use std::{fs, path::PathBuf};
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use formatting::format_serror;
 use komodo_client::entities::{
-  FileContents, RepoExecutionArgs,
+  FileContents, RepoExecutionArgs, all_logs_success,
   repo::Repo,
   stack::{Stack, StackRemoteFileContents},
   update::Log,
@@ -96,10 +96,27 @@ pub async fn ensure_remote_repo(
     clone_args.unique_path(&core_config().repo_directory)?;
   clone_args.destination = Some(repo_path.display().to_string());
 
-  git::pull_or_clone(clone_args, &config.repo_directory, access_token)
+  let (res, _) = git::pull_or_clone(clone_args, &config.repo_directory, access_token)
     .await
-    .context("Failed to clone stack repo")
-    .map(|(res, _)| {
-      (repo_path, res.logs, res.commit_hash, res.commit_message)
-    })
+    .context("Failed to clone stack repo")?;
+
+  if !all_logs_success(&res.logs) {
+    let failed_stages: Vec<_> = res.logs.iter()
+      .filter(|l| !l.success)
+      .map(|l| {
+        let detail = if !l.stderr.is_empty() {
+          &l.stderr
+        } else {
+          &l.stdout
+        };
+        format!("[{}] {}", l.stage, detail)
+      })
+      .collect();
+    return Err(anyhow!(
+      "Git operation failed:\n{}",
+      failed_stages.join("\n")
+    ));
+  }
+
+  Ok((repo_path, res.logs, res.commit_hash, res.commit_message))
 }


### PR DESCRIPTION
## Problem

When a git repository has an untrusted SSL certificate (or any other git error), the Global Auto Update feature fails silently — no error is shown to the user, and stacks/deployments just don't update. Users have no way to know why updates aren't happening.

This happens because:

1. **GlobalAutoUpdate** only checked for `Err` returns from `pull_stack_inner`/`pull_deployment_inner`, but git failures (SSL errors, auth failures, etc.) were returned as `Ok` with failed log entries inside the response. So failed pulls were marked with ✅ in the update history.

2. **RefreshStackCache** (periodic cache refresh) called `ensure_remote_repo` which returned `Ok` even when git operations failed, silently using stale cached data with no indication of failure.

3. **RefreshRepoCache** similarly didn't check git operation logs for failures, silently updating repo info with stale/missing commit data.

## Fix

- **GlobalAutoUpdate** (`maintenance.rs`): Now checks `all_logs_success` on the response from stack pulls and checks `log.success` for deployment pulls. Failed operations are recorded as error logs in the update history, visible in the UI.

- **ensure_remote_repo** (`stack/remote.rs`): Now returns an `Err` when git operations have failed logs, which surfaces through the refresh task warning logs and prevents stale data from being used silently.

- **RefreshRepoCache** (`repo.rs`): Now checks git operation logs and returns errors instead of silently proceeding with potentially stale data.

## Testing

- SSL cert errors in git fetch/pull will now appear as error logs in the Global Auto Update history
- Periodic resource refresh will log warnings when git operations fail
- The UI update history will show which specific git operation failed and the error message

Fixes #1138