### PR TITLE
fix: rename stack directory on server when stack is renamed

### DIFF
--- a/bin/core/src/api/write/stack.rs
+++ b/bin/core/src/api/write/stack.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, anyhow};
-use database::mungos::mongodb::bson::{doc, to_document};
+use database::mungos::{
+  by_id::update_one_by_id,
+  mongodb::bson::{doc, to_document},
+};
 use formatting::format_serror;
 use komodo_client::{
   api::write::*,
@@ -9,11 +12,13 @@ use komodo_client::{
     FileContents, NoData, Operation, RepoExecutionArgs,
     all_logs_success,
     config::core::CoreConfig,
+    komodo_timestamp,
     permission::PermissionLevel,
     repo::Repo,
-    server::ServerState,
+    server::{Server, ServerState},
     stack::{PartialStackConfig, Stack, StackInfo},
-    update::Update,
+    to_path_compatible_name,
+    update::{Log, Update},
     user::stack_user,
   },
 };
@@ -95,7 +100,67 @@ impl Resolve<WriteArgs> for RenameStack {
     self,
     WriteArgs { user }: &WriteArgs,
   ) -> serror::Result<Update> {
-    Ok(resource::rename::<Stack>(&self.id, &self.name, user).await?)
+    let stack = get_check_permissions::<Stack>(
+      &self.id,
+      user,
+      PermissionLevel::Write.into(),
+    )
+    .await?;
+
+    // If stack has no server, just do a simple DB rename
+    if stack.config.server_id.is_empty() {
+      return Ok(
+        resource::rename::<Stack>(&self.id, &self.name, user).await?,
+      );
+    }
+
+    let name = to_path_compatible_name(&self.name);
+
+    let mut update =
+      make_update(&stack, Operation::RenameStack, user);
+
+    update_one_by_id(
+      &db_client().stacks,
+      &stack.id,
+      database::mungos::update::Update::Set(
+        doc! { "name": &name, "updated_at": komodo_timestamp() },
+      ),
+      None,
+    )
+    .await
+    .context("Failed to update Stack name on db")?;
+
+    let server =
+      resource::get::<Server>(&stack.config.server_id).await?;
+
+    // Rename the stack directory on the periphery server
+    let log = match periphery_client(&server)?
+      .request(periphery_client::api::compose::RenameStack {
+        curr_name: to_path_compatible_name(&stack.name),
+        new_name: name.clone(),
+      })
+      .await
+      .context("Failed to rename Stack directory on Server")
+    {
+      Ok(log) => log,
+      Err(e) => Log::error(
+        "Rename Stack directory failure",
+        format_serror(&e.into()),
+      ),
+    };
+
+    update.logs.push(log);
+
+    update.push_simple_log(
+      "Rename Stack",
+      format!("Renamed Stack from {} to {}", stack.name, name),
+    );
+    update.finalize();
+    update.id = add_update(update.clone()).await?;
+
+    resource::refresh_all_resources_cache().await;
+
+    Ok(update)
   }
 }
 

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -93,6 +93,50 @@ pub struct DockerComposeLsItem {
 
 //
 
+impl Resolve<super::Args> for RenameStack {
+  #[instrument(name = "RenameStack")]
+  async fn resolve(self, _: &super::Args) -> serror::Result<Log> {
+    let RenameStack {
+      curr_name,
+      new_name,
+    } = self;
+    let stack_dir = periphery_config().stack_dir();
+    let curr_path = stack_dir.join(to_path_compatible_name(&curr_name));
+    let new_path = stack_dir.join(to_path_compatible_name(&new_name));
+    if !curr_path.exists() {
+      return Ok(Log::simple(
+        "Rename Stack on Server",
+        format!("No stack folder at {} to rename", curr_path.display()),
+      ));
+    }
+    if new_path.exists() {
+      return Ok(Log::error(
+        "Rename Stack on Server",
+        format!(
+          "Target folder {} already exists, cannot rename",
+          new_path.display()
+        ),
+      ));
+    }
+    match fs::rename(&curr_path, &new_path).await {
+      Ok(_) => Ok(Log::simple(
+        "Rename Stack on Server",
+        format!(
+          "Renamed stack directory from {} to {}",
+          curr_path.display(),
+          new_path.display()
+        ),
+      )),
+      Err(e) => Ok(Log::error(
+        "Rename Stack on Server",
+        format!("Failed to rename stack directory: {e}"),
+      )),
+    }
+  }
+}
+
+//
+
 impl Resolve<super::Args> for GetComposeLog {
   #[instrument(name = "GetComposeLog", level = "debug")]
   async fn resolve(self, _: &super::Args) -> serror::Result<Log> {

--- a/bin/periphery/src/api/mod.rs
+++ b/bin/periphery/src/api/mod.rs
@@ -80,6 +80,7 @@ pub enum PeripheryRequest {
   GetComposeLogSearch(GetComposeLogSearch),
 
   // Compose (Write)
+  RenameStack(RenameStack),
   WriteComposeContentsToHost(WriteComposeContentsToHost),
   WriteCommitComposeContents(WriteCommitComposeContents),
   ComposePull(ComposePull),

--- a/client/periphery/rs/src/api/compose.rs
+++ b/client/periphery/rs/src/api/compose.rs
@@ -23,6 +23,18 @@ pub struct ListComposeProjects {}
 
 //
 
+/// Rename a stack's directory on the host.
+/// Renames `stack_dir/<curr_name>` to `stack_dir/<new_name>`.
+#[derive(Debug, Clone, Serialize, Deserialize, Resolve)]
+#[response(Log)]
+#[error(serror::Error)]
+pub struct RenameStack {
+  pub curr_name: String,
+  pub new_name: String,
+}
+
+//
+
 /// Get the compose contents on the host, for stacks using
 /// `files_on_host`.
 #[derive(Debug, Clone, Serialize, Deserialize, Resolve)]


### PR DESCRIPTION
## Problem

When renaming a stack in Komodo, the old directory under `stack_dir` remained on disk while a new directory would be created on the next deploy. This wastes disk space and can cause confusion.

Closes #1030

## Solution

Added a `RenameStack` periphery API endpoint that renames the stack directory on the host server when a stack is renamed, following the same pattern used by repo renames (`RenameRepo`).

### Changes

- **`client/periphery/rs/src/api/compose.rs`**: Added `RenameStack` request type
- **`bin/periphery/src/api/mod.rs`**: Registered `RenameStack` in the `PeripheryRequest` enum
- **`bin/periphery/src/api/compose.rs`**: Implemented the handler that renames `stack_dir/<old_name>` to `stack_dir/<new_name>`, with safety checks for missing source and existing target directories
- **`bin/core/src/api/write/stack.rs`**: Updated `RenameStack` handler to call the periphery endpoint when the stack has a server assigned (stacks without a server still use the simple DB-only rename)

### Behavior

- If the old directory doesn't exist on the server, a non-error log is recorded
- If the target directory already exists, an error log is recorded
- If the stack has no server assigned, the rename is DB-only (unchanged behavior)
- Path-compatible names are used consistently via `to_path_compatible_name()`