### PR TITLE
fix: show all registry accounts in deployment when provider is not auto-detected

### DIFF
--- a/frontend/src/components/config/util.tsx
+++ b/frontend/src/components/config/util.tsx
@@ -823,7 +823,7 @@ export const AccountSelector = ({
   type: "Server" | "Builder" | "None";
   id?: string;
   account_type: "git" | "docker";
-  provider: string;
+  provider?: string;
   selected: string | undefined;
   onSelect: (id: string) => void;
   placeholder?: string;
@@ -838,10 +838,10 @@ export const AccountSelector = ({
   const config_params =
     type === "None" ? {} : { target: id ? { type, id } : undefined };
   const db_accounts = useRead(db_request, {}).data?.filter(
-    (account) => account.domain === provider
+    (account) => !provider || account.domain === provider
   );
   const config_providers = useRead(config_request, config_params).data?.filter(
-    (_provider) => _provider.domain === provider
+    (_provider) => !provider || _provider.domain === provider
   );
 
   const _accounts = new Set<string>();
@@ -895,7 +895,7 @@ export const AccountSelectorConfig = (params: {
   id?: string;
   type: "Server" | "Builder" | "None";
   account_type: "git" | "docker";
-  provider: string;
+  provider?: string;
   selected: string | undefined;
   onSelect: (id: string) => void;
   placeholder?: string;

--- a/frontend/src/components/resources/deployment/config/index.tsx
+++ b/frontend/src/components/resources/deployment/config/index.tsx
@@ -117,7 +117,7 @@ export const DeploymentConfig = ({
                     id={update.server_id ?? config.server_id ?? undefined}
                     type="Server"
                     account_type="docker"
-                    provider={provider ?? "docker.io"}
+                    provider={provider}
                     selected={account}
                     onSelect={(image_registry_account) =>
                       set({ image_registry_account })


### PR DESCRIPTION
## Summary

Fixes #1058 — non-docker.io registry accounts (e.g., ghcr.io, quay.io) were not shown in the Deployment Image account selection.

## Problem

When configuring a deployment's image registry account, the account selector auto-detects the registry provider from the image name. If the provider couldn't be determined (no image set yet, or image without a domain prefix), it defaulted to `docker.io`, filtering out all non-docker.io accounts.

This meant users who only configured registries like ghcr.io saw an empty account list.

## Fix

- Make `provider` optional in `AccountSelector` and `AccountSelectorConfig`
- When provider is `undefined`, show accounts from **all** registries instead of only `docker.io`
- Remove the `?? "docker.io"` fallback in deployment config

Provider auto-detection still works when possible:
- **Image type**: extracted from image name (e.g., `ghcr.io/org/repo` → `ghcr.io`)
- **Build type**: taken from the build's first image registry domain

## Files Changed

- `frontend/src/components/config/util.tsx` — make provider optional, skip domain filter when unset
- `frontend/src/components/resources/deployment/config/index.tsx` — pass provider as-is without docker.io fallback