### PR TITLE
fix: handle GitLab tag push and release webhook events

### DIFF
--- a/bin/core/src/listener/integrations/gitlab.rs
+++ b/bin/core/src/listener/integrations/gitlab.rs
@@ -37,15 +37,29 @@ impl VerifySecret for Gitlab {
 #[derive(Deserialize)]
 struct GitlabWebhookBody {
   #[serde(rename = "ref")]
-  branch: String,
+  git_ref: Option<String>,
+  /// Present in Release Hook payloads
+  tag: Option<String>,
 }
 
 impl ExtractBranch for Gitlab {
   fn extract_branch(body: &str) -> anyhow::Result<String> {
-    let branch = serde_json::from_str::<GitlabWebhookBody>(body)
-      .context("Failed to parse gitlab request body")?
-      .branch
-      .replace("refs/heads/", "");
-    Ok(branch)
+    let payload = serde_json::from_str::<GitlabWebhookBody>(body)
+      .context("Failed to parse gitlab request body")?;
+
+    // Release Hook: use the `tag` field directly
+    if let Some(tag) = payload.tag {
+      return Ok(tag);
+    }
+
+    // Push Hook / Tag Push Hook: strip refs/heads/ or refs/tags/ prefix
+    let git_ref = payload
+      .git_ref
+      .context("Gitlab webhook body has no 'ref' or 'tag' field")?;
+    let branch = git_ref
+      .strip_prefix("refs/heads/")
+      .or_else(|| git_ref.strip_prefix("refs/tags/"))
+      .unwrap_or(&git_ref);
+    Ok(branch.to_string())
   }
 }


### PR DESCRIPTION
## Problem

GitLab release and tag webhooks don't trigger stack redeployments (or any webhook-driven action). GitLab sends different payload formats for these event types:

- **Tag Push Hook**: `ref` is `refs/tags/<tag>` instead of `refs/heads/<branch>`
- **Release Hook**: Uses a `tag` field instead of `ref`

The existing GitLab webhook handler only stripped the `refs/heads/` prefix, so tag push events would fail branch matching (comparing `refs/tags/v1.0` against `v1.0`), and release events would fail to parse entirely since the `ref` field may not be present.

## Fix

Updated `GitlabWebhookBody` and `ExtractBranch` for GitLab to handle all three webhook formats:

1. **Push Hook**: `refs/heads/<branch>` → `<branch>` (existing behavior, preserved)
2. **Tag Push Hook**: `refs/tags/<tag>` → `<tag>`
3. **Release Hook**: Uses the `tag` field directly

Made the `ref` field optional and added an optional `tag` field to support the Release Hook payload structure.

## Usage

Users configure their stack's branch field to match the tag name (e.g., `v1.0`). When GitLab fires a Tag Push or Release webhook, the handler now correctly extracts and matches the tag.

Fixes #574