### PR TITLE
fix: use per-account docker config dirs to support multiple registry accounts on same domain

### DIFF
--- a/bin/periphery/src/api/build.rs
+++ b/bin/periphery/src/api/build.rs
@@ -27,7 +27,7 @@ use tokio::fs;
 use crate::{
   build::{parse_build_args, parse_secret_args, write_dockerfile},
   config::periphery_config,
-  docker::docker_login,
+  docker::{docker_config_flag, docker_login},
   helpers::{parse_extra_args, parse_labels},
 };
 
@@ -178,6 +178,7 @@ impl Resolve<super::Args> for build::Build {
 
     // Maybe docker login
     let mut should_push = false;
+    let mut login_config_dir = None;
     for (domain, account) in image_registry
       .iter()
       .map(|r| (r.domain.as_str(), r.account.as_str()))
@@ -191,8 +192,11 @@ impl Resolve<super::Args> for build::Build {
       )
       .await
       {
-        Ok(logged_in) if logged_in => should_push = true,
-        Ok(_) => {}
+        Ok(Some(dir)) => {
+          should_push = true;
+          login_config_dir = Some(dir);
+        }
+        Ok(None) => {}
         Err(e) => {
           logs.push(Log::error(
             "Docker Login",
@@ -292,9 +296,11 @@ impl Resolve<super::Args> for build::Build {
 
     let maybe_push = if should_push { " --push" } else { "" };
 
+    let config_flag = docker_config_flag(&login_config_dir);
+
     // Construct command
     let command = format!(
-      "docker{buildx} build{build_args}{command_secret_args}{extra_args}{labels}{image_tags}{maybe_push} -f {dockerfile_path} .",
+      "docker{config_flag}{buildx} build{build_args}{command_secret_args}{extra_args}{labels}{image_tags}{maybe_push} -f {dockerfile_path} .",
     );
 
     if let Some(build_log) = run_komodo_command_with_sanitization(

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -23,7 +23,8 @@ use tokio::fs;
 
 use crate::{
   compose::{
-    docker_compose, env_file_args, pull_or_clone_stack,
+    docker_compose, docker_compose_with_config, env_file_args,
+    pull_or_clone_stack,
     up::{maybe_login_registry, validate_files},
     write::write_stack,
   },
@@ -376,12 +377,15 @@ impl Resolve<super::Args> for ComposePull {
       }
     }
 
-    maybe_login_registry(&stack, registry_token, &mut res.logs).await;
+    let config_dir =
+      maybe_login_registry(&stack, registry_token, &mut res.logs)
+        .await;
     if !all_logs_success(&res.logs) {
       return Ok(res);
     }
 
-    let docker_compose = docker_compose();
+    let docker_compose =
+      docker_compose_with_config(&config_dir);
 
     let service_args = if services.is_empty() {
       String::new()
@@ -476,7 +480,9 @@ impl Resolve<super::Args> for ComposeUp {
       return Ok(res);
     }
 
-    maybe_login_registry(&stack, registry_token, &mut res.logs).await;
+    let config_dir =
+      maybe_login_registry(&stack, registry_token, &mut res.logs)
+        .await;
     if !all_logs_success(&res.logs) {
       return Ok(res);
     }
@@ -501,7 +507,8 @@ impl Resolve<super::Args> for ComposeUp {
       };
     }
 
-    let docker_compose = docker_compose();
+    let docker_compose =
+      docker_compose_with_config(&config_dir);
 
     let service_args = if services.is_empty() {
       String::new()
@@ -751,10 +758,12 @@ impl Resolve<super::Args> for ComposeRun {
       "Failed to validate run directory on host after stack write (canonicalize error)",
     )?;
 
-    maybe_login_registry(&stack, registry_token, &mut Vec::new())
-      .await;
+    let config_dir =
+      maybe_login_registry(&stack, registry_token, &mut Vec::new())
+        .await;
 
-    let docker_compose = docker_compose();
+    let docker_compose =
+      docker_compose_with_config(&config_dir);
 
     let file_args = if stack.config.file_paths.is_empty() {
       String::from("compose.yaml")

--- a/bin/periphery/src/api/deploy.rs
+++ b/bin/periphery/src/api/deploy.rs
@@ -64,22 +64,25 @@ impl Resolve<super::Args> for Deploy {
       ));
     };
 
-    if let Err(e) = docker_login(
+    let config_dir = match docker_login(
       &extract_registry_domain(image)?,
       &deployment.config.image_registry_account,
       registry_token.as_deref(),
     )
     .await
     {
-      return Ok(Log::error(
-        "docker login",
-        format_serror(
-          &e.context("failed to login to docker registry").into(),
-        ),
-      ));
-    }
+      Ok(dir) => dir,
+      Err(e) => {
+        return Ok(Log::error(
+          "docker login",
+          format_serror(
+            &e.context("failed to login to docker registry").into(),
+          ),
+        ));
+      }
+    };
 
-    let _ = pull_image(image).await;
+    let _ = pull_image(image, &config_dir).await;
     debug!("image pulled");
 
     let _ = (RemoveContainer {

--- a/bin/periphery/src/api/image.rs
+++ b/bin/periphery/src/api/image.rs
@@ -11,7 +11,7 @@ use komodo_client::entities::{
 use periphery_client::api::image::*;
 use resolver_api::Resolve;
 
-use crate::docker::{docker_client, docker_login};
+use crate::docker::{docker_client, docker_config_flag, docker_login};
 
 //
 
@@ -67,17 +67,18 @@ impl Resolve<super::Args> for PullImage {
     }
 
     let res = async {
-      docker_login(
+      let config_dir = docker_login(
         &extract_registry_domain(&name)?,
         account.as_deref().unwrap_or_default(),
         token.as_deref(),
       )
       .await?;
+      let config_flag = docker_config_flag(&config_dir);
       anyhow::Ok(
         run_komodo_command(
           "Docker Pull",
           None,
-          format!("docker pull {name}"),
+          format!("docker{config_flag} pull {name}"),
         )
         .await,
       )

--- a/bin/periphery/src/compose/mod.rs
+++ b/bin/periphery/src/compose/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, path::PathBuf};
+use std::{fmt::Write, path::{Path, PathBuf}};
 
 use anyhow::{Context, anyhow};
 use command::run_komodo_command;
@@ -21,6 +21,18 @@ pub fn docker_compose() -> &'static str {
     "docker-compose"
   } else {
     "docker compose"
+  }
+}
+
+/// Returns the `docker compose` command string with an optional
+/// `DOCKER_CONFIG` env var prefix for per-account registry auth.
+pub fn docker_compose_with_config(
+  config_dir: &Option<PathBuf>,
+) -> String {
+  let dc = docker_compose();
+  match config_dir {
+    Some(dir) => format!("DOCKER_CONFIG='{}' {dc}", dir.display()),
+    None => dc.to_string(),
   }
 }
 

--- a/bin/periphery/src/compose/up.rs
+++ b/bin/periphery/src/compose/up.rs
@@ -81,30 +81,39 @@ pub async fn validate_files(
   }
 }
 
+/// Returns a docker config directory path if login was performed,
+/// for use with `--config` in subsequent docker commands.
 pub async fn maybe_login_registry(
   stack: &Stack,
   registry_token: Option<String>,
   logs: &mut Vec<Log>,
-) {
-  if !stack.config.registry_provider.is_empty()
-    && !stack.config.registry_account.is_empty()
-    && let Err(e) = docker_login(
-      &stack.config.registry_provider,
-      &stack.config.registry_account,
-      registry_token.as_deref(),
-    )
-    .await
-    .with_context(|| {
-      format!(
-        "Domain: '{}' | Account: '{}'",
-        stack.config.registry_provider, stack.config.registry_account
-      )
-    })
-    .context("Failed to login to image registry")
+) -> Option<PathBuf> {
+  if stack.config.registry_provider.is_empty()
+    || stack.config.registry_account.is_empty()
   {
-    logs.push(Log::error(
-      "Login to Registry",
-      format_serror(&e.into()),
-    ));
+    return None;
+  }
+  match docker_login(
+    &stack.config.registry_provider,
+    &stack.config.registry_account,
+    registry_token.as_deref(),
+  )
+  .await
+  .with_context(|| {
+    format!(
+      "Domain: '{}' | Account: '{}'",
+      stack.config.registry_provider, stack.config.registry_account
+    )
+  })
+  .context("Failed to login to image registry")
+  {
+    Ok(config_dir) => config_dir,
+    Err(e) => {
+      logs.push(Log::error(
+        "Login to Registry",
+        format_serror(&e.into()),
+      ));
+      None
+    }
   }
 }

--- a/bin/periphery/src/docker/mod.rs
+++ b/bin/periphery/src/docker/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use anyhow::anyhow;
@@ -31,27 +32,34 @@ impl Default for DockerClient {
   }
 }
 
-/// Returns whether build result should be pushed after build
+/// Returns a docker config directory path if login was performed.
+/// Uses a per-(domain, account) config directory so that multiple
+/// accounts on the same registry domain don't overwrite each other's
+/// credentials (fixes #1063).
 #[instrument(skip(registry_token))]
 pub async fn docker_login(
   domain: &str,
   account: &str,
   // For local token override from core.
   registry_token: Option<&str>,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<Option<PathBuf>> {
   if domain.is_empty() || account.is_empty() {
-    return Ok(false);
+    return Ok(None);
   }
   let registry_token = match registry_token {
     Some(token) => token,
     None => crate::helpers::registry_token(domain, account)?,
   };
+  let config_dir = docker_config_dir(domain, account);
+  // Ensure the config directory exists
+  std::fs::create_dir_all(&config_dir).ok();
+  let config_arg = config_dir.display();
   let log = async_run_command(&format!(
-    "echo {registry_token} | docker login {domain} --username '{account}' --password-stdin",
+    "echo {registry_token} | docker --config '{config_arg}' login {domain} --username '{account}' --password-stdin",
   ))
   .await;
   if log.success() {
-    Ok(true)
+    Ok(Some(config_dir))
   } else {
     let mut e = anyhow!("End of trace");
     for line in
@@ -68,9 +76,35 @@ pub async fn docker_login(
   }
 }
 
+/// Returns a stable, per-(domain, account) config directory path
+/// under `/tmp/komodo-docker-config/`.
+pub fn docker_config_dir(domain: &str, account: &str) -> PathBuf {
+  use std::collections::hash_map::DefaultHasher;
+  use std::hash::{Hash, Hasher};
+  let mut hasher = DefaultHasher::new();
+  domain.hash(&mut hasher);
+  account.hash(&mut hasher);
+  let hash = hasher.finish();
+  PathBuf::from(format!(
+    "/tmp/komodo-docker-config/{domain}-{hash:x}"
+  ))
+}
+
+/// Format a `--config` flag for docker commands if a config dir is provided.
+pub fn docker_config_flag(config_dir: &Option<PathBuf>) -> String {
+  match config_dir {
+    Some(dir) => format!(" --config '{}'", dir.display()),
+    None => String::new(),
+  }
+}
+
 #[instrument]
-pub async fn pull_image(image: &str) -> Log {
-  let command = format!("docker pull {image}");
+pub async fn pull_image(
+  image: &str,
+  config_dir: &Option<PathBuf>,
+) -> Log {
+  let config_flag = docker_config_flag(config_dir);
+  let command = format!("docker{config_flag} pull {image}");
   run_komodo_command("Docker Pull", None, command).await
 }
 


### PR DESCRIPTION
## Problem

When two different accounts are configured for the same private Docker registry domain (e.g., two accounts on the same GHCR or private registry), only the first account's credentials work. The second account's authentication fails because `docker login` writes to a shared `~/.docker/config.json`, and a second login for the same domain overwrites the first account's credentials.

This issue was reported in #1063 - users who have multiple accounts on the same registry (common with private registries) can only authenticate with one account at a time.

## Solution

Give each (domain, account) pair its own isolated Docker config directory under `/tmp/komodo-docker-config/<domain>-<hash>/`. This ensures credentials for different accounts on the same registry domain coexist without overwriting each other.

### Changes

- **`docker login`**: Now uses `--config <per-account-dir>` to store credentials in isolated directories. Returns the config dir path (`Option<PathBuf>`) instead of a boolean.
- **`docker pull`**: Accepts and uses the config dir via `--config` flag.
- **`docker build`**: Uses `--config` flag when pushing to a registry.
- **`docker compose`**: Uses `DOCKER_CONFIG` environment variable prefix for compose commands (pull, up, build, run).

### Files Modified

- `bin/periphery/src/docker/mod.rs` - Core `docker_login`, `pull_image`, new helpers `docker_config_dir` and `docker_config_flag`
- `bin/periphery/src/api/deploy.rs` - Pass config dir to pull_image
- `bin/periphery/src/api/build.rs` - Pass config dir to docker build
- `bin/periphery/src/api/image.rs` - Pass config dir to docker pull
- `bin/periphery/src/api/compose.rs` - Use DOCKER_CONFIG for compose commands
- `bin/periphery/src/compose/mod.rs` - New `docker_compose_with_config` helper
- `bin/periphery/src/compose/up.rs` - Return config dir from `maybe_login_registry`

Fixes #1063