### PR TITLE
let user specify if they want command split into multiple lines

### DIFF
--- a/bin/core/src/alert/discord.rs
+++ b/bin/core/src/alert/discord.rs
@@ -230,14 +230,12 @@ pub async fn send_alert(
       )
     }
     AlertData::Custom { message, details } => {
-      format!(
-        "{level} | {message}{}",
-        if details.is_empty() {
-          format_args!("")
-        } else {
-          format_args!("\n{details}")
-        }
-      )
+      let details_str = if details.is_empty() {
+        String::new()
+      } else {
+        format!("\n{details}")
+      };
+      format!("{level} | {message}{details_str}")
     }
     AlertData::None {} => Default::default(),
   };

--- a/bin/core/src/alert/mod.rs
+++ b/bin/core/src/alert/mod.rs
@@ -474,14 +474,12 @@ fn standard_alert_content(alert: &Alert) -> String {
       )
     }
     AlertData::Custom { message, details } => {
-      format!(
-        "{level} | {message}{}",
-        if details.is_empty() {
-          format_args!("")
-        } else {
-          format_args!("\n{details}")
-        }
-      )
+      let details_str = if details.is_empty() {
+        String::new()
+      } else {
+        format!("\n{details:#?}")
+      };
+      format!("{level} | {message}{details_str}")
     }
     AlertData::None {} => Default::default(),
   }

--- a/bin/periphery/src/api/build.rs
+++ b/bin/periphery/src/api/build.rs
@@ -247,7 +247,7 @@ impl Resolve<super::Args> for build::Build {
         "Pre Build",
         pre_build_path.as_path(),
         &pre_build.command,
-        true,
+        pre_build.parse_multiline,
         &replacers,
       )
       .await

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -489,7 +489,7 @@ impl Resolve<super::Args> for ComposeUp {
         "Pre Deploy",
         pre_deploy_path.as_path(),
         &stack.config.pre_deploy.command,
-        true,
+        stack.config.pre_deploy.parse_multiline,
         &replacers,
       )
       .await
@@ -667,7 +667,7 @@ impl Resolve<super::Args> for ComposeUp {
         "Post Deploy",
         post_deploy_path.as_path(),
         &stack.config.post_deploy.command,
-        true,
+        stack.config.post_deploy.parse_multiline,
         &replacers,
       )
       .await

--- a/bin/periphery/src/api/mod.rs
+++ b/bin/periphery/src/api/mod.rs
@@ -252,7 +252,7 @@ impl Resolve<Args> for RunCommand {
   #[instrument(name = "RunCommand")]
   async fn resolve(self, _: &Args) -> serror::Result<Log> {
     let RunCommand {
-      command: SystemCommand { path, command },
+      command: SystemCommand { path, command, parse_multiline: _ },
     } = self;
     let res = tokio::spawn(async move {
       let command = if path.is_empty() {

--- a/bin/periphery/src/git.rs
+++ b/bin/periphery/src/git.rs
@@ -56,7 +56,7 @@ pub async fn handle_post_repo_execution(
       "On Clone",
       path.as_path(),
       on_clone.command,
-      true,
+      on_clone.parse_multiline,
       &replacers,
     )
     .await
@@ -81,7 +81,7 @@ pub async fn handle_post_repo_execution(
       "On Pull",
       path.as_path(),
       on_pull.command,
-      true,
+      on_pull.parse_multiline,
       &replacers,
     )
     .await

--- a/client/core/rs/src/entities/mod.rs
+++ b/client/core/rs/src/entities/mod.rs
@@ -184,6 +184,8 @@ pub struct SystemCommand {
   pub path: String,
   #[serde(default, deserialize_with = "file_contents_deserializer")]
   pub command: String,
+  #[serde(default)]
+  pub parse_multiline: bool,
 }
 
 impl SystemCommand {

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -566,6 +566,7 @@ export interface ImageRegistryConfig {
 export interface SystemCommand {
 	path?: string;
 	command?: string;
+	parse_multiline?: boolean;
 }
 
 /** The build configuration. */

--- a/frontend/public/client/types.d.ts
+++ b/frontend/public/client/types.d.ts
@@ -564,6 +564,7 @@ export interface ImageRegistryConfig {
 export interface SystemCommand {
     path?: string;
     command?: string;
+    parse_multiline?: boolean;
 }
 /** The build configuration. */
 export interface BuildConfig {

--- a/frontend/src/components/config/util.tsx
+++ b/frontend/src/components/config/util.tsx
@@ -63,6 +63,7 @@ import {
 } from "@components/monaco";
 import { useNavigate } from "react-router-dom";
 import { Badge } from "@ui/badge";
+import { Checkbox } from "@ui/checkbox";
 
 export const ConfigItem = ({
   label,
@@ -469,6 +470,12 @@ export const SystemCommand = ({
   disabled: boolean;
   set: (value: Types.SystemCommand) => void;
 }) => {
+  const initContent = (() => {
+    if (value?.parse_multiline) {
+      return "  # Add multiple commands on new lines. Supports comments and escaped newlines.\n  ";
+    }
+    return "  # Add a command to run.\n  ";
+  })();
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
@@ -481,10 +488,25 @@ export const SystemCommand = ({
           disabled={disabled}
         />
       </div>
+      <div className="flex items-center gap-1">
+        <Checkbox
+          checked={value?.parse_multiline ?? false}
+          onCheckedChange={(checked) =>
+            set({
+              ...(value || {}),
+              parse_multiline: checked === true ? true : false,
+            })
+          }
+          disabled={disabled}
+        />
+        <div className="text-sm text-muted-foreground">
+          Split lines into multiple commands. Supports comments, and escaped newlines.
+        </div>
+      </div>
       <MonacoEditor
         value={
           value?.command ||
-          "  # Add multiple commands on new lines. Supports comments.\n  "
+          initContent
         }
         language="shell"
         onValueChange={(command) => set({ ...(value || {}), command })}


### PR DESCRIPTION
It's a bit confusing when I write a command and it doesn't work. 
Turns out the spliting behavior is not doing what I want it to do.
So I want a way to turn it off.
I think it make sense to provide user the ability to turn it off.

<img width="758" height="299" alt="Screenshot 2026-02-24 at 09 23 10" src="https://github.com/user-attachments/assets/188f0149-d106-454e-b571-654b299ed336" />
<img width="726" height="304" alt="Screenshot 2026-02-24 at 09 23 14" src="https://github.com/user-attachments/assets/0da21c5d-895f-47df-a80c-375a654b0175" />


Relates to but not entirely the same ask from #808