### PR TITLE
improve delete button styling

### DIFF
--- a/ui/src/components/swarm/remove.tsx
+++ b/ui/src/components/swarm/remove.tsx
@@ -35,7 +35,7 @@ export default function RemoveSwarmResource({
   return (
     <ConfirmModalWithDisable
       confirmText={resourceName ?? resourceId}
-      targetProps={{ variant: "filled", color: "red" }}
+      targetProps={{ variant: "outline", color: "red" }}
       icon={<ICONS.Delete size="1rem" />}
       disabled={disabled || isPending}
       loading={isPending}

--- a/ui/src/components/user/delete-group.tsx
+++ b/ui/src/components/user/delete-group.tsx
@@ -24,7 +24,7 @@ export default function DeleteUserGroup({ group }: { group: Types.UserGroup }) {
 
   return (
     <ConfirmModal
-      targetProps={{ variant: "filled", color: "red" }}
+      targetProps={{ variant: "outline", color: "red" }}
       icon={<ICONS.Delete size="1rem" />}
       onConfirm={() => deleteGroup({ id: group._id?.$oid! })}
       confirmText={group.name}

--- a/ui/src/components/user/table.tsx
+++ b/ui/src/components/user/table.tsx
@@ -57,7 +57,7 @@ export default function UserTable({
       header: "Remove",
       cell: ({ row }) => (
         <ConfirmButton
-          variant="filled"
+          variant="outline"
           color="red"
           icon={<ICONS.Remove size="1rem" />}
           onClick={(e) => {
@@ -76,7 +76,7 @@ export default function UserTable({
       header: "Delete",
       cell: ({ row }) => (
         <ConfirmModal
-          targetProps={{ variant: "filled", color: "red" }}
+          targetProps={{ variant: "outline", color: "red" }}
           icon={<ICONS.Delete size="1rem" />}
           confirmText={row.original.username}
           onConfirm={() => onUserDelete(row.original._id?.$oid!)}

--- a/ui/src/pages/docker/image.tsx
+++ b/ui/src/pages/docker/image.tsx
@@ -116,7 +116,7 @@ function ImageInner({
           executions={
             unused && (
               <ConfirmButton
-                variant="filled"
+                variant="outline"
                 color="red"
                 icon={<ICONS.Delete size="1rem" />}
                 loading={deletePending}

--- a/ui/src/pages/docker/network.tsx
+++ b/ui/src/pages/docker/network.tsx
@@ -131,7 +131,7 @@ function NetworkInner({
       executions={
         unused ? (
           <ConfirmButton
-            variant="filled"
+            variant="outline"
             color="red"
             icon={<ICONS.Delete size="1rem" />}
             loading={deletePending}

--- a/ui/src/pages/docker/volume.tsx
+++ b/ui/src/pages/docker/volume.tsx
@@ -117,6 +117,7 @@ function VolumeInner({
       executions={
         unused && (
           <ConfirmButton
+            variant="outline"
             color="red"
             icon={<ICONS.Delete size="1rem" />}
             loading={deletePending}

--- a/ui/src/pages/profile/passkey.tsx
+++ b/ui/src/pages/profile/passkey.tsx
@@ -68,7 +68,7 @@ export const EnrollPasskey = ({ user }: { user: Types.User }) => {
           icon={<Trash size="1rem" />}
           loading={unenrollPending}
           onConfirm={() => unenroll({})}
-          targetProps={{ variant: "filled", color: "red", c: "bw", w: 220 }}
+          targetProps={{ variant: "outline", color: "red", w: 220 }}
         >
           Unenroll Passkey 2FA
         </ConfirmModal>

--- a/ui/src/pages/profile/totp.tsx
+++ b/ui/src/pages/profile/totp.tsx
@@ -135,7 +135,7 @@ export const EnrollTotp = ({ user }: { user: Types.User }) => {
           icon={<Trash size="1rem" />}
           loading={unenrollPending}
           onConfirm={() => unenroll({})}
-          targetProps={{ variant: "filled", color: "red", c: "bw", w: 220 }}
+          targetProps={{ variant: "outline", color: "red", w: 220 }}
         >
           Unenroll TOTP 2FA
         </ConfirmModal>

--- a/ui/src/pages/settings/providers/delete.tsx
+++ b/ui/src/pages/settings/providers/delete.tsx
@@ -19,7 +19,7 @@ export default function DeleteProviderAccount({
   });
   return (
     <ConfirmButton
-      variant="filled"
+      variant="outline"
       color="red"
       icon={<ICONS.Delete size="1rem" />}
       onClick={() => mutate({ id })}

--- a/ui/src/pages/terminals/batch-delete.tsx
+++ b/ui/src/pages/terminals/batch-delete.tsx
@@ -19,7 +19,7 @@ export default function BatchDeleteAllTerminals({
   const { tags } = useTags();
   return (
     <ConfirmButton
-      variant="filled"
+      variant="outline"
       color="red"
       icon={<ICONS.Delete size="1rem" />}
       w={160}

--- a/ui/src/pages/terminals/delete.tsx
+++ b/ui/src/pages/terminals/delete.tsx
@@ -32,7 +32,7 @@ export default function DeleteTerminal({
   });
   return (
     <ConfirmButton
-      variant="filled"
+      variant="outline"
       color="red"
       icon={<ICONS.Delete size="1rem" />}
       onClick={() => mutate({ target, terminal })}

--- a/ui/src/pages/user-group/delete.tsx
+++ b/ui/src/pages/user-group/delete.tsx
@@ -25,7 +25,7 @@ export default function DeleteUserGroup({ groupId }: { groupId: string }) {
       confirmButtonContent="Delete"
       icon={<ICONS.Delete size="1rem" />}
       targetNoIcon
-      targetProps={{ variant: "filled", color: "red", w: "fit", px: "xs" }}
+      targetProps={{ variant: "outline", color: "red", w: "fit", px: "xs" }}
       confirmText={group?.name ?? ""}
       onConfirm={() => mutateAsync({ id: groupId })}
       loading={isPending}

--- a/ui/src/resources/delete.tsx
+++ b/ui/src/resources/delete.tsx
@@ -34,7 +34,7 @@ export default function DeleteResource({
       confirmButtonContent="Delete"
       icon={<ICONS.Delete size="1rem" />}
       targetNoIcon
-      targetProps={{ variant: "filled", color: "red", w: "fit", px: "xs" }}
+      targetProps={{ variant: "outline", color: "red", w: "fit", px: "xs" }}
       confirmText={resource.name}
       onConfirm={() => mutateAsync({ id })}
       loading={isPending}

--- a/ui/src/resources/swarm/config.tsx
+++ b/ui/src/resources/swarm/config.tsx
@@ -79,7 +79,7 @@ export default function SwarmConfig({
                             clearable={false}
                           />
                           {!disabled && (
-                            <ActionIcon variant="filled" color="red">
+                            <ActionIcon variant="subtle" color="red">
                               <ICONS.Remove
                                 size="1rem"
                                 onClick={() =>

--- a/ui/src/ui/confirm-button.tsx
+++ b/ui/src/ui/confirm-button.tsx
@@ -70,13 +70,16 @@ const ConfirmButton = createPolymorphicComponent<"button", ConfirmButtonProps>(
             clickedOnce ? (
               <Check size="1rem" />
             ) : loading ? (
-              <Loader color="white" size="1rem" />
+              <Loader size="1rem" />
             ) : (
               (rightSection ?? icon ?? <ICONS.Unknown size="1rem" />)
             )
           }
           disabled={disabled || loading}
           {...props}
+          {...(clickedOnce
+            ? { variant: "filled", color: "red" }
+            : {})}
           ref={ref}
         >
           {clickedOnce ? "Confirm" : children}

--- a/ui/src/ui/confirm-modal.tsx
+++ b/ui/src/ui/confirm-modal.tsx
@@ -117,6 +117,8 @@ export default function ConfirmModal({
 
           <Group justify="end">
             <Button
+              variant="filled"
+              color="red"
               justify="space-between"
               w={{ base: "100%", xs: 190 }}
               miw="fit-content"


### PR DESCRIPTION
the filled red delete buttons have too much visual weight, especially given that they all have a confirmation step after. this changes the pattern to: subtle styling (e.g. outline button) before first click -> filled red for confirm.

The Resource page headers are where this is most obvious.

Before:

<img width="1684" height="454" alt="header-before" src="https://github.com/user-attachments/assets/4f032ebf-8cf0-48db-b170-252da38f5371" />


after:

<img width="1688" height="466" alt="header-after" src="https://github.com/user-attachments/assets/62a7f206-ef16-4bbd-8665-5adeb34e01f6" />

Similarly, the 2-click standalone buttons.

Before:

![standalone-before](https://github.com/user-attachments/assets/5dd1c1d2-35e8-4b81-b5d2-a2939b570aec)

After:

![standalone-after](https://github.com/user-attachments/assets/2b874032-b27e-4724-a8df-73a930810036)

Modals had the inverse logic.

Before:


![modal-before](https://github.com/user-attachments/assets/f40a6d40-544a-41c9-827d-65d66fe743c7)

After:

![modal-after](https://github.com/user-attachments/assets/6dba28bb-609a-47e8-bcc5-85b5af1581e4)




