### PR TITLE
let user specify if they want command to be run in shell-mode

### DIFF
--- a/bin/periphery/src/api/build/mod.rs
+++ b/bin/periphery/src/api/build/mod.rs
@@ -271,7 +271,7 @@ impl Resolve<crate::api::Args> for build::Build {
         "Pre Build",
         pre_build_path.as_path(),
         &pre_build.command,
-        KomodoCommandMode::Multiline,
+        if pre_build.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
         &replacers,
       )
       .instrument(span)

--- a/bin/periphery/src/api/build/mod.rs
+++ b/bin/periphery/src/api/build/mod.rs
@@ -271,7 +271,11 @@ impl Resolve<crate::api::Args> for build::Build {
         "Pre Build",
         pre_build_path.as_path(),
         &pre_build.command,
-        if pre_build.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
+        if pre_build.shell_mode {
+          KomodoCommandMode::Shell
+        } else {
+          KomodoCommandMode::Multiline
+        },
         &replacers,
       )
       .instrument(span)

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -490,7 +490,7 @@ impl Resolve<crate::api::Args> for ComposeUp {
         "Pre Deploy",
         pre_deploy_path.as_path(),
         &stack.config.pre_deploy.command,
-        KomodoCommandMode::Multiline,
+        if stack.config.pre_deploy.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
         &replacers,
       )
       .instrument(span)
@@ -760,7 +760,7 @@ impl Resolve<crate::api::Args> for ComposeUp {
         "Post Deploy",
         post_deploy_path.as_path(),
         &stack.config.post_deploy.command,
-        KomodoCommandMode::Multiline,
+        if stack.config.post_deploy.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
         &replacers,
       )
       .instrument(span)

--- a/bin/periphery/src/api/compose.rs
+++ b/bin/periphery/src/api/compose.rs
@@ -490,7 +490,11 @@ impl Resolve<crate::api::Args> for ComposeUp {
         "Pre Deploy",
         pre_deploy_path.as_path(),
         &stack.config.pre_deploy.command,
-        if stack.config.pre_deploy.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
+        if stack.config.pre_deploy.shell_mode {
+          KomodoCommandMode::Shell
+        } else {
+          KomodoCommandMode::Multiline
+        },
         &replacers,
       )
       .instrument(span)
@@ -760,7 +764,11 @@ impl Resolve<crate::api::Args> for ComposeUp {
         "Post Deploy",
         post_deploy_path.as_path(),
         &stack.config.post_deploy.command,
-        if stack.config.post_deploy.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
+        if stack.config.post_deploy.shell_mode {
+          KomodoCommandMode::Shell
+        } else {
+          KomodoCommandMode::Multiline
+        },
         &replacers,
       )
       .instrument(span)

--- a/bin/periphery/src/helpers.rs
+++ b/bin/periphery/src/helpers.rs
@@ -189,7 +189,11 @@ pub async fn handle_post_repo_execution(
       "On Clone",
       path.as_path(),
       on_clone.command,
-      if on_clone.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
+      if on_clone.shell_mode {
+        KomodoCommandMode::Shell
+      } else {
+        KomodoCommandMode::Multiline
+      },
       &replacers,
     )
     .await
@@ -214,7 +218,11 @@ pub async fn handle_post_repo_execution(
       "On Pull",
       path.as_path(),
       on_pull.command,
-      if on_pull.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
+      if on_pull.shell_mode {
+        KomodoCommandMode::Shell
+      } else {
+        KomodoCommandMode::Multiline
+      },
       &replacers,
     )
     .await

--- a/bin/periphery/src/helpers.rs
+++ b/bin/periphery/src/helpers.rs
@@ -189,7 +189,7 @@ pub async fn handle_post_repo_execution(
       "On Clone",
       path.as_path(),
       on_clone.command,
-      KomodoCommandMode::Multiline,
+      if on_clone.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
       &replacers,
     )
     .await
@@ -214,7 +214,7 @@ pub async fn handle_post_repo_execution(
       "On Pull",
       path.as_path(),
       on_pull.command,
-      KomodoCommandMode::Multiline,
+      if on_pull.shell_mode { KomodoCommandMode::Shell } else { KomodoCommandMode::Multiline },
       &replacers,
     )
     .await

--- a/client/core/rs/src/entities/mod.rs
+++ b/client/core/rs/src/entities/mod.rs
@@ -215,6 +215,8 @@ pub struct SystemCommand {
   pub path: String,
   #[serde(default, deserialize_with = "file_contents_deserializer")]
   pub command: String,
+  #[serde(default)]
+  pub shell_mode: bool,
 }
 
 impl SystemCommand {

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -611,6 +611,7 @@ export interface ImageRegistryConfig {
 export interface SystemCommand {
 	path?: string;
 	command?: string;
+	shell_mode?: boolean;
 }
 
 /** The build configuration. */

--- a/ui/package.json
+++ b/ui/package.json
@@ -50,6 +50,5 @@
     "sass-embedded": "^1.97.3",
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -50,5 +50,6 @@
     "sass-embedded": "^1.97.3",
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -606,6 +606,7 @@ export interface ImageRegistryConfig {
 export interface SystemCommand {
     path?: string;
     command?: string;
+    shell_mode?: boolean;
 }
 /** The build configuration. */
 export interface BuildConfig {

--- a/ui/src/components/config/system-command.tsx
+++ b/ui/src/components/config/system-command.tsx
@@ -1,4 +1,4 @@
-import { Stack, TextInput } from "@mantine/core";
+import { Checkbox, Code, Stack, TextInput } from "@mantine/core";
 import { Types } from "komodo_client";
 import { MonacoEditor } from "@/components/monaco";
 
@@ -13,6 +13,9 @@ export default function SystemCommand({
   disabled,
   set,
 }: SystemCommandProps) {
+  const placeholder = value?.shell_mode
+    ? "  # Add a command to run.\n  "
+    : "  # Add multiple commands on new lines. Supports comments and escaped newlines.\n  ";
   return (
     <Stack>
       <TextInput
@@ -23,11 +26,27 @@ export default function SystemCommand({
         onChange={(e) => set({ ...(value || {}), path: e.target.value })}
         disabled={disabled}
       />
-      <MonacoEditor
-        value={
-          value?.command ||
-          "  # Add multiple commands on new lines. Supports comments.\n  "
+      <Checkbox
+        label={
+          <>
+            Run in shell mode (
+            <Code fz="sm" p="0">
+              sh -c
+            </Code>
+            ){" "}
+          </>
         }
+        checked={value?.shell_mode ?? false}
+        onChange={(e) =>
+          set({
+            ...(value || {}),
+            shell_mode: e.currentTarget.checked,
+          })
+        }
+        disabled={disabled}
+      />
+      <MonacoEditor
+        value={value?.command || placeholder}
         language="shell"
         onValueChange={(command) => set({ ...(value || {}), command })}
         readOnly={disabled}


### PR DESCRIPTION
This is a follow up to https://github.com/moghtech/komodo/pull/1217 in v2.

In v2, things are easier because there's an explicit shell-mode. This makes this change easier to implement and won't cause backwards incompitable changes for existing configs.


Makes something like the following possible:

<img width="462" height="402" alt="Screenshot 2026-03-24 at 19 30 41" src="https://github.com/user-attachments/assets/e759bc33-28d8-4eb8-af6d-fd78b8dc861a" />

Without this option, scripts like this would fail for reason like:
```
bash: This: command not found
```

Would improve #808

closes #1217