### PR TITLE
Prevent horizontal page scroll on long log lines

### DIFF
--- a/ui/src/components/updates/details.tsx
+++ b/ui/src/components/updates/details.tsx
@@ -200,7 +200,7 @@ export function UpdateDetailsContent({ id }: { id: string }) {
                   dangerouslySetInnerHTML={{
                     __html: updateLogToHtml(log.stdout),
                   }}
-                  style={{ overflowY: "auto" }}
+                  style={{ overflowY: "auto", whiteSpace: "pre-wrap" }}
                 />
               </Stack>
             )}
@@ -214,7 +214,7 @@ export function UpdateDetailsContent({ id }: { id: string }) {
                   dangerouslySetInnerHTML={{
                     __html: updateLogToHtml(log.stderr),
                   }}
-                  style={{ overflowY: "auto" }}
+                  style={{ overflowY: "auto", whiteSpace: "pre-wrap" }}
                 />
               </Stack>
             )}

--- a/ui/src/resources/action/last-run.tsx
+++ b/ui/src/resources/action/last-run.tsx
@@ -48,7 +48,7 @@ export default function ActionLastRun({ id }: { id: string }) {
             dangerouslySetInnerHTML={{
               __html: updateLogToHtml(log.stdout),
             }}
-            style={{ overflowY: "auto" }}
+            style={{ overflowY: "auto", whiteSpace: "pre-wrap" }}
           />
         </Stack>
       )}
@@ -65,7 +65,7 @@ export default function ActionLastRun({ id }: { id: string }) {
             dangerouslySetInnerHTML={{
               __html: updateLogToHtml(log.stderr),
             }}
-            style={{ overflowY: "auto" }}
+            style={{ overflowY: "auto", whiteSpace: "pre-wrap" }}
           />
         </Stack>
       )}

--- a/ui/src/resources/build/info.tsx
+++ b/ui/src/resources/build/info.tsx
@@ -101,7 +101,7 @@ export default function BuildInfo({
             dangerouslySetInnerHTML={{
               __html: updateLogToHtml(remoteError),
             }}
-            style={{ overflowY: "auto" }}
+            style={{ overflowY: "auto", whiteSpace: "pre-wrap" }}
           />
         </Stack>
       )}
@@ -233,7 +233,7 @@ export default function BuildInfo({
                   dangerouslySetInnerHTML={{
                     __html: updateLogToHtml(log.stdout),
                   }}
-                  style={{ overflowY: "auto" }}
+                  style={{ overflowY: "auto", whiteSpace: "pre-wrap" }}
                 />
               </Stack>
             )}
@@ -247,7 +247,7 @@ export default function BuildInfo({
                   dangerouslySetInnerHTML={{
                     __html: updateLogToHtml(log.stderr),
                   }}
-                  style={{ overflowY: "auto" }}
+                  style={{ overflowY: "auto", whiteSpace: "pre-wrap" }}
                 />
               </Stack>
             )}


### PR DESCRIPTION
Small update to add white-space: pre wrap to a few places where logs are converted to HTML. In cases where logs printed a long single line, the line wasn't breaking. Horizontal scrolling the entire page was required to see logs, which was not a pleasant user experience.

**action/last-run.tsx**

Before (image 1: haven't scrolled yet, image 2: scrolled all the way to the right)
<img width="1728" height="908" alt="Screenshot 2026-03-24 at 5 53 11 PM" src="https://github.com/user-attachments/assets/09b8c845-2786-47ac-9ea7-638f9fe82596" />
<img width="1728" height="904" alt="Screenshot 2026-03-24 at 5 53 15 PM" src="https://github.com/user-attachments/assets/12e77644-8e41-465a-972e-d08b2749f348" />


After:
<img width="1715" height="901" alt="Screenshot 2026-03-24 at 4 10 12 PM" src="https://github.com/user-attachments/assets/385e2b5d-b63e-4ac4-afc1-5cf4a8e01edd" />


Was not able to test changes for build/info.tsx as I don't use that feature, but have attached screenshots for the **updates/details.tsx** changes below as well. I believe they should all behave similarly.

Before (image 1: haven't scrolled yet, image 2: scrolled all the way to the right)
<img width="1728" height="927" alt="Screenshot 2026-03-24 at 5 49 51 PM" src="https://github.com/user-attachments/assets/fbdb2ae1-75d7-4756-9ed7-6ef45390d8c0" />
<img width="1728" height="930" alt="Screenshot 2026-03-24 at 5 49 55 PM" src="https://github.com/user-attachments/assets/d1f33609-715e-44e9-a9d3-8eac951f5ff6" />

After:
<img width="1728" height="934" alt="Screenshot 2026-03-24 at 5 40 16 PM" src="https://github.com/user-attachments/assets/54f4a2f4-d8ab-4b9a-9b8a-23fab0c2c3d4" />
