### PR TITLE
Show/hide button non-functional in stack, sync, and build info views

### DIFF
--- a/ui/src/resources/build/info.tsx
+++ b/ui/src/resources/build/info.tsx
@@ -168,8 +168,7 @@ export default function BuildInfo({
                   />
                 </>
               )}
-              {/* The toggle onClick is given to entire header */}
-              <ShowHideButton show={show} setShow={() => {}} />
+              <ShowHideButton show={show} setShow={() => setShow((show) => !show)} />
             </Group>
           </Group>
 

--- a/ui/src/resources/stack/info.tsx
+++ b/ui/src/resources/stack/info.tsx
@@ -180,8 +180,7 @@ export default function StackInfo({
                       />
                     </>
                   )}
-                  {/* The toggle onClick is given to entire header */}
-                  <ShowHideButton show={showContents} setShow={() => {}} />
+                  <ShowHideButton show={showContents} setShow={handleToggleShow} />
                 </Group>
               </Group>
 

--- a/ui/src/resources/sync/info.tsx
+++ b/ui/src/resources/sync/info.tsx
@@ -190,8 +190,7 @@ export default function ResourceSyncInfo({
                       />
                     </>
                   )}
-                  {/* The toggle onClick is given to entire header */}
-                  <ShowHideButton show={showContents} setShow={() => {}} />
+                  <ShowHideButton show={showContents} setShow={handleToggleShow} />
                 </Group>
               </Group>
 


### PR DESCRIPTION
Show/hide button wasn't revealing file contents in Komodo's various info sections. Just added setShow on button click.

Before:

https://github.com/user-attachments/assets/caa15af6-f763-4165-bbde-4e14a15b1dc4



After:

https://github.com/user-attachments/assets/447ef3f6-87d6-4c3a-b20c-286c9205882f
