### PR TITLE
Allow excluding services from global auto update 

### DIFF
--- a/bin/core/src/api/write/stack.rs
+++ b/bin/core/src/api/write/stack.rs
@@ -775,7 +775,13 @@ pub async fn check_stack_for_update_inner(
 
     if image.is_empty() ||
       // Images with a hardcoded digest can't have update.
-      image.contains('@')
+      image.contains('@') ||
+      // Services explicitly excluded from global auto-update checks.
+      // Manual checks should still evaluate all services.
+      (wait_for_auto_update &&
+        stack.config.ignore_polling_services.contains(
+          &service.service_name,
+        ))
     {
       service.image_digest = None;
       continue;

--- a/bin/core/src/api/write/stack.rs
+++ b/bin/core/src/api/write/stack.rs
@@ -779,7 +779,7 @@ pub async fn check_stack_for_update_inner(
       // Services explicitly excluded from global auto-update checks.
       // Manual checks should still evaluate all services.
       (wait_for_auto_update &&
-        stack.config.ignore_polling_services.contains(
+        stack.config.auto_update_skip_services.contains(
           &service.service_name,
         ))
     {

--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -601,6 +601,17 @@ pub struct StackConfig {
   #[builder(default)]
   pub ignore_services: Vec<String>,
 
+  /// Ignore certain services during Global Auto Update polling.
+  /// Services listed here are skipped only in the global auto-update flow.
+  /// Manual checks still include all services.
+  #[serde(default, deserialize_with = "string_list_deserializer")]
+  #[partial_attr(serde(
+    default,
+    deserialize_with = "option_string_list_deserializer"
+  ))]
+  #[builder(default)]
+  pub ignore_polling_services: Vec<String>,
+
   /// The contents of the file directly, for management in the UI.
   /// If this is empty, it will fall back to checking git config for
   /// repo based compose file.
@@ -689,6 +700,7 @@ impl Default for StackConfig {
       auto_update: Default::default(),
       auto_update_all_services: Default::default(),
       ignore_services: Default::default(),
+      ignore_polling_services: Default::default(),
       pre_deploy: Default::default(),
       post_deploy: Default::default(),
       extra_args: Default::default(),

--- a/client/core/rs/src/entities/stack.rs
+++ b/client/core/rs/src/entities/stack.rs
@@ -371,6 +371,17 @@ pub struct StackConfig {
   #[builder(default)]
   pub auto_update_all_services: bool,
 
+  /// Ignore certain services during Global Auto Update polling.
+  /// Services listed here are skipped only in the global auto-update flow.
+  /// Manual checks still include all services.
+  #[serde(default, deserialize_with = "string_list_deserializer")]
+  #[partial_attr(serde(
+    default,
+    deserialize_with = "option_string_list_deserializer"
+  ))]
+  #[builder(default)]
+  pub auto_update_skip_services: Vec<String>,
+
   /// Whether to run `docker compose down` before `compose up`.
   #[serde(default)]
   #[builder(default)]
@@ -601,17 +612,6 @@ pub struct StackConfig {
   #[builder(default)]
   pub ignore_services: Vec<String>,
 
-  /// Ignore certain services during Global Auto Update polling.
-  /// Services listed here are skipped only in the global auto-update flow.
-  /// Manual checks still include all services.
-  #[serde(default, deserialize_with = "string_list_deserializer")]
-  #[partial_attr(serde(
-    default,
-    deserialize_with = "option_string_list_deserializer"
-  ))]
-  #[builder(default)]
-  pub ignore_polling_services: Vec<String>,
-
   /// The contents of the file directly, for management in the UI.
   /// If this is empty, it will fall back to checking git config for
   /// repo based compose file.
@@ -699,8 +699,8 @@ impl Default for StackConfig {
       poll_for_updates: Default::default(),
       auto_update: Default::default(),
       auto_update_all_services: Default::default(),
+      auto_update_skip_services: Default::default(),
       ignore_services: Default::default(),
-      ignore_polling_services: Default::default(),
       pre_deploy: Default::default(),
       post_deploy: Default::default(),
       extra_args: Default::default(),

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -2455,6 +2455,12 @@ export interface StackConfig {
 	/** Whether to poll for any updates to the images. */
 	poll_for_updates?: boolean;
 	/**
+	 * Ignore certain services during Global Auto Update polling.
+	 * Services listed here are skipped only in the global auto-update flow.
+	 * Manual checks still include all services.
+	 */
+	ignore_polling_services?: string[];
+	/**
 	 * Whether to automatically redeploy when
 	 * newer images are found. Will implicitly
 	 * enable `poll_for_updates`, you don't need to

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -2455,12 +2455,6 @@ export interface StackConfig {
 	/** Whether to poll for any updates to the images. */
 	poll_for_updates?: boolean;
 	/**
-	 * Ignore certain services during Global Auto Update polling.
-	 * Services listed here are skipped only in the global auto-update flow.
-	 * Manual checks still include all services.
-	 */
-	ignore_polling_services?: string[];
-	/**
 	 * Whether to automatically redeploy when
 	 * newer images are found. Will implicitly
 	 * enable `poll_for_updates`, you don't need to
@@ -2474,6 +2468,12 @@ export interface StackConfig {
 	 * Komodo will redeploy the whole Stack (all services).
 	 */
 	auto_update_all_services?: boolean;
+	/**
+	 * Ignore certain services during Global Auto Update polling.
+	 * Services listed here are skipped only in the global auto-update flow.
+	 * Manual checks still include all services.
+	 */
+	auto_update_skip_services?: string[];
 	/** Whether to run `docker compose down` before `compose up`. */
 	destroy_before_deploy?: boolean;
 	/** Whether to skip secret interpolation into the stack environment variables. */

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -2604,6 +2604,12 @@ export interface StackConfig {
      */
     auto_update?: boolean;
     /**
+     * Ignore certain services during Global Auto Update polling.
+     * Services listed here are skipped only in the global auto-update flow.
+     * Manual checks still include all services.
+     */
+    ignore_polling_services?: string[];
+    /**
      * If auto update is enabled, Komodo will
      * by default only update the specific services
      * with image updates. If this parameter is set to true,

--- a/ui/public/client/types.d.ts
+++ b/ui/public/client/types.d.ts
@@ -2604,18 +2604,18 @@ export interface StackConfig {
      */
     auto_update?: boolean;
     /**
-     * Ignore certain services during Global Auto Update polling.
-     * Services listed here are skipped only in the global auto-update flow.
-     * Manual checks still include all services.
-     */
-    ignore_polling_services?: string[];
-    /**
      * If auto update is enabled, Komodo will
      * by default only update the specific services
      * with image updates. If this parameter is set to true,
      * Komodo will redeploy the whole Stack (all services).
      */
     auto_update_all_services?: boolean;
+    /**
+     * Ignore certain services during Global Auto Update polling.
+     * Services listed here are skipped only in the global auto-update flow.
+     * Manual checks still include all services.
+     */
+    auto_update_skip_services?: string[];
     /** Whether to run `docker compose down` before `compose up`. */
     destroy_before_deploy?: boolean;
     /** Whether to skip secret interpolation into the stack environment variables. */

--- a/ui/src/resources/stack/config/index.tsx
+++ b/ui/src/resources/stack/config/index.tsx
@@ -95,6 +95,8 @@ export default function StackConfig({
   const disabled = global_disabled || !canWrite;
 
   const runBuild = update.run_build ?? config.run_build;
+  const poll_for_updates = update.poll_for_updates ?? config.poll_for_updates;
+
   const mode = getStackMode(update, config);
 
   const gitProvider = update.git_provider ?? config.git_provider;
@@ -390,6 +392,27 @@ export default function StackConfig({
             />
           );
         },
+        ignore_polling_services: (values, set) =>
+          poll_for_updates && (
+            <ConfigItem
+              label="Ignore Services During Polling"
+              description="Services listed here are skipped only during Global Auto Update checks. Manual checks still include all services."
+            >
+              <MultiSelect
+                leftSection={<ICONS.Service size="1rem" />}
+                placeholder={values?.length ? "Add services" : "Select services"}
+                value={values}
+                data={allServices}
+                onChange={(ignore_polling_services) =>
+                  set({ ignore_polling_services })
+                }
+                disabled={disabled}
+                w="fit-content"
+                searchable
+                clearable
+              />
+            </ConfigItem>
+          ),
         auto_update: {
           description: "Trigger a redeploy if a newer image is found.",
         },

--- a/ui/src/resources/stack/config/index.tsx
+++ b/ui/src/resources/stack/config/index.tsx
@@ -392,7 +392,7 @@ export default function StackConfig({
             />
           );
         },
-        ignore_polling_services: (values, set) =>
+        auto_update_skip_services: (values, set) =>
           poll_for_updates && (
             <ConfigItem
               label="Ignore Services During Polling"
@@ -403,8 +403,8 @@ export default function StackConfig({
                 placeholder={values?.length ? "Add services" : "Select services"}
                 value={values}
                 data={allServices}
-                onChange={(ignore_polling_services) =>
-                  set({ ignore_polling_services })
+                onChange={(auto_update_skip_services) =>
+                  set({ auto_update_skip_services })
                 }
                 disabled={disabled}
                 w="fit-content"


### PR DESCRIPTION
Problem:
We have our Global Auto Update set to run every 3 minutes, which depletes docker hub limits really fast. Only one service in our stack needs to be constantly checked for updates (and it's on ghcr.io, so no rate limit problem). 
One of the solutions was to set specific image digests (@sha256:...) for all services using images from docker hub in compose.yaml, but then when you want to update - you have to manually check for digests and replace them in compose.yaml.

Solution:
This PR adds new option, which allows you to exclude services from Global Auto Updates checks (manual checks still look for new digest).

When poll for updates disabled:
<img width="380" height="208" alt="obraz" src="https://github.com/user-attachments/assets/91a51347-3917-423c-bf42-ee6738e8ef44" />

When poll for updates enabled:
<img width="664" height="311" alt="obraz" src="https://github.com/user-attachments/assets/7c394362-d713-4a48-8324-a5e1f6a0b7eb" />
