### PR TITLE
fix missing nullish check when selecting stack

### DIFF
--- a/ui/src/components/stack-service-selector.tsx
+++ b/ui/src/components/stack-service-selector.tsx
@@ -51,7 +51,7 @@ export default function StackServiceSelector({
     stack: stackId,
   }).data?.filter((service) => !state || service?.container?.state === state);
 
-  const firstService = services?.[0].service;
+  const firstService = services?.[0]?.service;
   useEffect(() => {
     !clearable && firstService && !selected && onSelect?.(firstService);
   }, [firstService]);


### PR DESCRIPTION
Ran into a crash when creating terminal when I select type "stack" while I have 0 stacks configured.

Page crashes with following error:
<img width="627" height="790" alt="Screenshot 2026-03-27 at 23 33 31" src="https://github.com/user-attachments/assets/2dcb4db3-eb73-4c17-90b8-8c920585994f" />

Looked at the code and looks like a simple case of missing null check.

Side note: Should we enable frontend source map in the builds?