### PR TITLE
fix: periphery handle_socket CLOSE_WAIT leak — use tokio::join instead of tokio::select

### DIFF
--- a/bin/periphery/src/connection/mod.rs
+++ b/bin/periphery/src/connection/mod.rs
@@ -9,6 +9,7 @@ use periphery_client::transport::{
   EncodedRequestMessage, EncodedTransportMessage, RequestMessage,
   TransportMessage,
 };
+use tokio_util::sync::CancellationToken;
 use transport::{
   auth::{
     ConnectionIdentifiers, LoginFlow, LoginFlowArgs,
@@ -16,7 +17,8 @@ use transport::{
   },
   channel::{BufferedReceiver, Sender},
   websocket::{
-    Websocket, WebsocketReceiverExt as _, WebsocketSender as _,
+    Websocket, WebsocketReceiver as _, WebsocketReceiverExt as _,
+    WebsocketSender as _,
   },
 };
 
@@ -79,7 +81,12 @@ async fn handle_socket<W: Websocket>(
     }
   );
 
+  let cancel = CancellationToken::new();
+
   let (mut ws_write, mut ws_read) = socket.split();
+
+  ws_read.set_cancel(cancel.clone());
+  receiver.set_cancel(cancel.clone());
 
   let forward_writes = async {
     loop {
@@ -110,6 +117,7 @@ async fn handle_socket<W: Websocket>(
       }
     }
     let _ = ws_write.close().await;
+    cancel.cancel();
   };
 
   let handle_reads = async {
@@ -132,12 +140,10 @@ async fn handle_socket<W: Websocket>(
         _ => {}
       }
     }
+    cancel.cancel();
   };
 
-  tokio::select! {
-    _ = forward_writes => {},
-    _ = handle_reads => {},
-  }
+  tokio::join!(forward_writes, handle_reads);
 }
 
 fn handle_request(


### PR DESCRIPTION
## Summary

Periphery's `handle_socket` uses `tokio::select!` to race the WebSocket read and write
futures. When the read side detects disconnection first (the common case — core closes
the connection), `select!` drops the write future, skipping `ws_write.close()`. This
causes TCP sockets to accumulate in CLOSE_WAIT indefinitely.

Core's identical function already uses `tokio::join!` + `CancellationToken` for
coordinated shutdown (see `bin/core/src/connection/mod.rs:416`). This PR aligns
periphery with that pattern.

## The bug

In `bin/periphery/src/connection/mod.rs`, `handle_socket` previously had:

```rust
tokio::select! {
    _ = forward_writes => {},
    _ = handle_reads => {},
}
```

When `handle_reads` finishes first, `forward_writes` is dropped mid-execution.
`ws_write.close()` (which sits at the end of `forward_writes`) never runs. The
WebSocket write half is dropped without a close frame, and the TCP connection
lingers in CLOSE_WAIT.

## The fix

- Add a `CancellationToken` shared between both futures
- Set cancel on `ws_read` and `receiver` so they unblock when the other side exits
- Both futures call `cancel.cancel()` on break
- Replace `tokio::select!` with `tokio::join!`

This matches core's `handle_socket` at `bin/core/src/connection/mod.rs:355-419`.

## Observed impact

On a system running v2.0.0 with ~30 containers, periphery accumulated 193
CLOSE_WAIT sockets to core:9120 over 4 hours, with periphery and core each
consuming ~55% CPU. Core (which uses `join!`) had 0 leaked sockets.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo build` passes
- [x] `cargo test` passes
- [ ] Deploy and verify CLOSE_WAIT sockets no longer accumulate
  (`cat /proc/<periphery_pid>/net/tcp | awk '{print $4}' | grep '06' | wc -l`)