### PR TITLE
Add per-provider user registration control

### DIFF
--- a/bin/core/src/auth/mod.rs
+++ b/bin/core/src/auth/mod.rs
@@ -205,6 +205,20 @@ impl AuthImpl for KomodoAuthImpl {
     core_config().disable_user_registration
   }
 
+  fn local_registration_disabled(&self) -> bool {
+    let config = core_config();
+    config
+      .disable_local_user_registration
+      .unwrap_or(config.disable_user_registration)
+  }
+
+  fn oidc_registration_disabled(&self) -> bool {
+    let config = core_config();
+    config
+      .disable_oidc_user_registration
+      .unwrap_or(config.disable_user_registration)
+  }
+
   fn validate_username(
     &self,
     username: &str,

--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -345,6 +345,12 @@ pub fn core_config() -> &'static CoreConfig {
       disable_user_registration: env
         .komodo_disable_user_registration
         .unwrap_or(config.disable_user_registration),
+      disable_local_user_registration: env
+        .komodo_disable_local_user_registration
+        .or(config.disable_local_user_registration),
+      disable_oidc_user_registration: env
+        .komodo_disable_oidc_user_registration
+        .or(config.disable_oidc_user_registration),
       disable_non_admin_create: env
         .komodo_disable_non_admin_create
         .unwrap_or(config.disable_non_admin_create),

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -124,6 +124,10 @@ pub struct Env {
   pub komodo_enable_new_users: Option<bool>,
   /// Override `disable_user_registration`
   pub komodo_disable_user_registration: Option<bool>,
+  /// Override `disable_local_user_registration`
+  pub komodo_disable_local_user_registration: Option<bool>,
+  /// Override `disable_oidc_user_registration`
+  pub komodo_disable_oidc_user_registration: Option<bool>,
   /// Override `lock_login_credentials_for`
   pub komodo_lock_login_credentials_for: Option<Vec<String>>,
   /// Override `disable_confirm_dialog`
@@ -456,6 +460,20 @@ pub struct CoreConfig {
   /// With `disable_user_registration = true`, only the first user to log in will registered as a user.
   #[serde(default)]
   pub disable_user_registration: bool,
+
+  /// Disable local (username/password) user registration only.
+  /// When set, the "Sign Up" button is hidden and local signups are blocked,
+  /// but OIDC and other external provider signups are still allowed.
+  /// If not set, falls back to `disable_user_registration`.
+  #[serde(default)]
+  pub disable_local_user_registration: Option<bool>,
+
+  /// Disable OIDC user registration only.
+  /// When set, new users cannot register via OIDC,
+  /// but local and other provider signups are still allowed.
+  /// If not set, falls back to `disable_user_registration`.
+  #[serde(default)]
+  pub disable_oidc_user_registration: Option<bool>,
 
   /// List of usernames for which the update username / password
   /// APIs are disabled. Used by demo to lock the 'demo' : 'demo' login.
@@ -826,6 +844,8 @@ impl Default for CoreConfig {
       transparent_mode: Default::default(),
       enable_new_users: Default::default(),
       disable_user_registration: Default::default(),
+      disable_local_user_registration: Default::default(),
+      disable_oidc_user_registration: Default::default(),
       lock_login_credentials_for: Default::default(),
       disable_non_admin_create: Default::default(),
       jwt_secret: Default::default(),
@@ -909,6 +929,10 @@ impl CoreConfig {
       enable_fancy_toml: config.enable_fancy_toml,
       enable_new_users: config.enable_new_users,
       disable_user_registration: config.disable_user_registration,
+      disable_local_user_registration: config
+        .disable_local_user_registration,
+      disable_oidc_user_registration: config
+        .disable_oidc_user_registration,
       disable_non_admin_create: config.disable_non_admin_create,
       lock_login_credentials_for: config.lock_login_credentials_for,
       local_auth: config.local_auth,

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -167,6 +167,20 @@ init_admin_password = "changeme"
 ## Default: false
 disable_user_registration = false
 
+## Disable local (username/password) user registration only.
+## When set to true, the "Sign Up" button is hidden and local signups are blocked,
+## but OIDC and other external provider signups are still allowed.
+## If not set, falls back to `disable_user_registration`.
+## Env: KOMODO_DISABLE_LOCAL_USER_REGISTRATION
+# disable_local_user_registration = true
+
+## Disable OIDC user registration only.
+## When set to true, new users cannot register via OIDC,
+## but local and other provider signups are still allowed.
+## If not set, falls back to `disable_user_registration`.
+## Env: KOMODO_DISABLE_OIDC_USER_REGISTRATION
+# disable_oidc_user_registration = true
+
 ## New users will be automatically enabled when they sign up.
 ## Otherwise, new users will be disabled on first login.
 ## The first user to login will always be enabled on creation.


### PR DESCRIPTION
Add granular registration flags:
- KOMODO_DISABLE_LOCAL_USER_REGISTRATION - blocks local signups, hides Sign Up button, while allowing OIDC registration
- KOMODO_DISABLE_OIDC_USER_REGISTRATION - blocks OIDC signups while allowing local registration

Both are optional and fall back to the existing
KOMODO_DISABLE_USER_REGISTRATION when not set. This enables the common pattern of letting your OIDC provider control access while preventing direct local account creation.

Depends on mogh-lib change adding per-provider registration methods to the AuthImpl trait: https://github.com/moghtech/lib/pull/2

Closes #1087