### PR TITLE
Add OIDC auto-redirect config to Core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "mogh_auth_client"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06919a6e06dfd611efa91a00fc618a49e0ceedb60f709980c74bbf4047213d4"
+checksum = "cff148cedbc122317e701713e84e3a4bb76d7dba3b6a898afde3faddd1806369"
 dependencies = [
  "anyhow",
  "mogh_error",
@@ -3226,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "mogh_auth_server"
-version = "1.2.13"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d649dff8bdacff15df7d65716fcc4e3b1643bbc970d609d31cb45b3e2e02b9ac"
+checksum = "d4bf631dc6c3d096c334b332c6ba49b727fe38016883dcff0a62d95c393ab9ea"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ slack = { version = "2.0.0", package = "slack_client_rs", default-features = fal
 mogh_error = { version = "1.0.3", default-features = false }
 derive_default_builder = "0.1.8"
 async_timing_util = "1.1.0"
-mogh_auth_client = "1.2.2"
-mogh_auth_server = "1.2.13"
+mogh_auth_client = "1.3.0"
+mogh_auth_server = "1.3.0"
 mogh_secret_file = "1.0.1"
 mogh_validations = "1.0.1"
 mogh_rate_limit = "1.0.1"

--- a/bin/core/src/auth/mod.rs
+++ b/bin/core/src/auth/mod.rs
@@ -348,6 +348,7 @@ impl AuthImpl for KomodoAuthImpl {
         additional_audiences: config
           .oidc_additional_audiences
           .clone(),
+        auto_redirect: config.oidc_auto_redirect,
       }
     });
     Some(&OIDC_CONFIG)

--- a/bin/core/src/config.rs
+++ b/bin/core/src/config.rs
@@ -235,6 +235,9 @@ pub fn core_config() -> &'static CoreConfig {
         env.komodo_oidc_additional_audiences,
       )
       .unwrap_or(config.oidc_additional_audiences),
+      oidc_auto_redirect: env
+        .komodo_oidc_auto_redirect
+        .unwrap_or(config.oidc_auto_redirect),
       google_oauth: NamedOauthConfig {
         enabled: env
           .komodo_google_oauth_enabled

--- a/client/core/rs/src/entities/config/core.rs
+++ b/client/core/rs/src/entities/config/core.rs
@@ -170,6 +170,8 @@ pub struct Env {
   pub komodo_oidc_additional_audiences: Option<Vec<String>>,
   /// Override `oidc_additional_audiences` from file
   pub komodo_oidc_additional_audiences_file: Option<PathBuf>,
+  /// Override `oidc_auto_redirect`
+  pub komodo_oidc_auto_redirect: Option<bool>,
 
   /// Override `google_oauth.enabled`
   pub komodo_google_oauth_enabled: Option<bool>,
@@ -525,6 +527,12 @@ pub struct CoreConfig {
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub oidc_additional_audiences: Vec<String>,
 
+  /// Automatically redirect unauthenticated users to the OIDC provider
+  /// instead of showing the login page.
+  /// Users can bypass the redirect by appending `?disableAutoLogin` to the login URL.
+  #[serde(default)]
+  pub oidc_auto_redirect: bool,
+
   // =========
   // = Oauth =
   // =========
@@ -837,6 +845,7 @@ impl Default for CoreConfig {
       oidc_client_secret: Default::default(),
       oidc_use_full_email: Default::default(),
       oidc_additional_audiences: Default::default(),
+      oidc_auto_redirect: Default::default(),
       google_oauth: Default::default(),
       github_oauth: Default::default(),
       auth_rate_limit_disabled: Default::default(),
@@ -932,6 +941,7 @@ impl CoreConfig {
         .iter()
         .map(|aud| empty_or_redacted(aud))
         .collect(),
+      oidc_auto_redirect: config.oidc_auto_redirect,
       google_oauth: NamedOauthConfig {
         enabled: config.google_oauth.enabled,
         client_id: empty_or_redacted(&config.google_oauth.client_id),

--- a/config/core.config.toml
+++ b/config/core.config.toml
@@ -267,6 +267,13 @@ oidc_use_full_email = false
 ## Default: empty
 oidc_additional_audiences = []
 
+## Automatically redirect unauthenticated users to the OIDC provider
+## instead of showing the login page.
+## Users can bypass the redirect by appending `?disableAutoLogin` to the login URL.
+## Env: KOMODO_OIDC_AUTO_REDIRECT
+## Default: false
+oidc_auto_redirect = false
+
 #########
 # OAUTH #
 #########

--- a/ui/src/app/topbar/user-dropdown.tsx
+++ b/ui/src/app/topbar/user-dropdown.tsx
@@ -104,7 +104,7 @@ export default function UserDropdown() {
               onClick={() => {
                 setOpen(false);
                 nav(
-                  `/login?${new URLSearchParams({ backto: `${location.pathname}${location.search}` })}`,
+                  `/login?${new URLSearchParams({ backto: `${location.pathname}${location.search}`, disableAutoLogin: "true" })}`,
                 );
               }}
             >


### PR DESCRIPTION
When KOMODO_OIDC_AUTO_REDIRECT=true, the login options response includes oidc_auto_redirect, enabling the UI (via mogh-lib) to automatically redirect unauthenticated users to the OIDC provider. Users can bypass by appending ?disableAutoLogin to the login URL.

Depends on moghtech/lib UI change adding auto-redirect to LoginPage: https://github.com/moghtech/lib/pull/3

Closes #311