### PR TITLE
Minor: Update periphery.config.toml

### DIFF
--- a/compose/compose.env
+++ b/compose/compose.env
@@ -145,6 +145,7 @@ PERIPHERY_CORE_PUBLIC_KEYS=file:/config/keys/core.pub
 ## ------ ./my_stack_2
 ## --- ./repos
 ## ------ ./my_repo_1
+## --- ./builds
 PERIPHERY_ROOT_DIRECTORY=/etc/komodo
 
 ## Specify whether to disable the terminals feature

--- a/config/periphery.config.toml
+++ b/config/periphery.config.toml
@@ -33,6 +33,7 @@
 ## ------ ./my_stack_2
 ## --- ./repos
 ## ------ ./my_repo_1
+## --- ./builds
 ## Each specific sub-directory (like ./stacks) can be overridden below.
 ## Env: PERIPHERY_ROOT_DIRECTORY
 ## Default: /etc/komodo


### PR DESCRIPTION
Make docs on ROOT_DIRECTORY more clear

This change relates to line:
> Each specific sub-directory (like ./stacks) can be overridden below.

The change includes `./builds` directory to the list as it also can be overridden. Thus, a reader will have better understanding of the resulting root directory structure